### PR TITLE
test(iot): cover P0 data pipeline components

### DIFF
--- a/iot-server/src/main/java/com/github/dingdaoyi/driver/mqtt/model/MqttTopic.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/driver/mqtt/model/MqttTopic.java
@@ -27,8 +27,12 @@ public class MqttTopic {
         if (!matcher.find()) {
             return Optional.empty();
         }
+        Optional<ProtoMessageType> messageType = ProtoMessageType.fromCode(matcher.group(1));
+        if (messageType.isEmpty()) {
+            return Optional.empty();
+        }
         MqttTopic mqttTopic = new MqttTopic();
-        mqttTopic.setMessageType(ProtoMessageType.fromCode(matcher.group(1)).orElse(null));
+        mqttTopic.setMessageType(messageType.get());
         mqttTopic.setProductKey(matcher.group(2));
         return Optional.of(mqttTopic);
     }

--- a/iot-server/src/test/java/com/github/dingdaoyi/driver/mqtt/model/MqttTopicTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/driver/mqtt/model/MqttTopicTest.java
@@ -1,0 +1,75 @@
+package com.github.dingdaoyi.driver.mqtt.model;
+
+import com.github.dingdaoyi.driver.DriverConfig;
+import com.github.dingdaoyi.driver.mqtt.MqttTopicConstants;
+import com.github.dingdaoyi.proto.model.ProtoMessageType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ResourceLock("MqttTopicConstants")
+class MqttTopicTest {
+
+    private Map<String, String> originalTopicMap;
+    private Pattern originalTopicParsePattern;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUpTopicPattern() {
+        originalTopicMap = new HashMap<>((Map<String, String>) ReflectionTestUtils.getField(MqttTopicConstants.class, "TOPIC_MAP"));
+        originalTopicParsePattern = MqttTopicConstants.TOPIC_PARSE_PATTERN;
+
+        DriverConfig.MqttConfigProperties mqttConfig = new DriverConfig.MqttConfigProperties();
+        mqttConfig.setTopicPrefix("iot");
+        DriverConfig driverConfig = mock(DriverConfig.class);
+        when(driverConfig.getMqtt()).thenReturn(mqttConfig);
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        when(applicationContext.getBean(DriverConfig.class)).thenReturn(driverConfig);
+
+        new MqttTopicConstants().setApplicationContext(applicationContext);
+    }
+
+    @AfterEach
+    @SuppressWarnings("unchecked")
+    void restoreTopicPattern() {
+        Map<String, String> topicMap = (Map<String, String>) ReflectionTestUtils.getField(MqttTopicConstants.class, "TOPIC_MAP");
+        topicMap.clear();
+        topicMap.putAll(originalTopicMap);
+        MqttTopicConstants.TOPIC_PARSE_PATTERN = originalTopicParsePattern;
+    }
+
+    @Test
+    void parseReturnsPropertyTopicWhenKnownMessageTypeMatchesPrefix() {
+        Optional<MqttTopic> topic = MqttTopic.parse("iot/pro/PK001");
+
+        assertThat(topic).isPresent();
+        assertThat(topic.get().getMessageType()).isEqualTo(ProtoMessageType.PROPERTY);
+        assertThat(topic.get().getProductKey()).isEqualTo("PK001");
+    }
+
+    @Test
+    void parseRejectsUnknownMessageTypeInsteadOfReturningNullType() {
+        Optional<MqttTopic> topic = MqttTopic.parse("iot/unknown/PK001");
+
+        assertThat(topic).isEmpty();
+    }
+
+    @Test
+    void getTopicAppliesConfiguredPrefix() {
+        String topic = MqttTopicConstants.getTopic(MqttTopicConstants.PROPERTY_TOPIC, "PK001");
+
+        assertThat(topic).isEqualTo("iot/pro/PK001");
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/iot/influx/InfluxDataProcessorTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/iot/influx/InfluxDataProcessorTest.java
@@ -1,0 +1,84 @@
+package com.github.dingdaoyi.iot.influx;
+
+import com.github.dingdaoyi.config.base.IotConfigProperties;
+import com.github.dingdaoyi.proto.model.DataTypeEnum;
+import com.github.dingdaoyi.proto.model.DecodeResult;
+import com.github.dingdaoyi.proto.model.DeviceData;
+import com.github.dingdaoyi.proto.model.tsl.TslModel;
+import com.influxdb.v3.client.InfluxDBClient;
+import com.influxdb.v3.client.Point;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class InfluxDataProcessorTest {
+
+    @Mock
+    private InfluxDBClient influxDBClient;
+
+    private InfluxDataProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        IotConfigProperties properties = new IotConfigProperties();
+        IotConfigProperties.InfluxDbProperties influx = new IotConfigProperties.InfluxDbProperties();
+        influx.setDatabase("iot_bucket");
+        influx.setPropDatabase("properties");
+        influx.setEventDatabase("events");
+        properties.setInfluxdb(influx);
+
+        processor = new InfluxDataProcessor();
+        ReflectionTestUtils.setField(processor, "influxDBClient", influxDBClient);
+        processor.setProperties(properties);
+    }
+
+    @Test
+    void processWritesPropertiesToProductScopedMeasurementWithTypedFields() {
+        DecodeResult result = new DecodeResult();
+        result.setDataList(List.of(
+            new DeviceData("temperature", DataTypeEnum.DOUBLE, "21.5"),
+            new DeviceData("humidity", DataTypeEnum.INT, "60"),
+            new DeviceData("online", DataTypeEnum.BOOL, "true"),
+            new DeviceData("status", DataTypeEnum.TEXT, "ok"),
+            new DeviceData("ignored", DataTypeEnum.TEXT, null)
+        ));
+        TslModel tslModel = new TslModel();
+        tslModel.setProductKey("PK001");
+
+        processor.process(result, "device-1", tslModel);
+
+        ArgumentCaptor<Point> pointCaptor = ArgumentCaptor.forClass(Point.class);
+        verify(influxDBClient).writePoint(pointCaptor.capture());
+        Point point = pointCaptor.getValue();
+        assertThat(point.getMeasurement()).isEqualTo("properties_pk001");
+        assertThat(point.getTag("deviceKey")).isEqualTo("device-1");
+        assertThat(point.getField("temperature")).isEqualTo(21.5D);
+        assertThat(point.getField("humidity")).isEqualTo(60L);
+        assertThat(point.getField("online")).isEqualTo(true);
+        assertThat(point.getField("status")).isEqualTo("ok");
+        assertThat(point.getField("ignored")).isNull();
+    }
+
+    @Test
+    void processDoesNotWritePointWhenPropertyListIsEmpty() {
+        DecodeResult result = new DecodeResult();
+        result.setDataList(List.of());
+        TslModel tslModel = new TslModel();
+        tslModel.setProductKey("PK001");
+
+        processor.process(result, "device-1", tslModel);
+
+        verify(influxDBClient, never()).writePoint(org.mockito.ArgumentMatchers.any(Point.class));
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/iot/proto/ProtocolFactoryTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/iot/proto/ProtocolFactoryTest.java
@@ -1,0 +1,71 @@
+package com.github.dingdaoyi.iot.proto;
+
+import com.github.dingdaoyi.proto.inter.DeviceConnection;
+import com.github.dingdaoyi.proto.inter.ProtocolDecoder;
+import com.github.dingdaoyi.proto.model.DecodeResult;
+import com.github.dingdaoyi.proto.model.DeviceRequest;
+import com.github.dingdaoyi.proto.model.EncoderMessage;
+import com.github.dingdaoyi.proto.model.EncoderResult;
+import com.github.dingdaoyi.proto.model.ProtocolException;
+import com.github.dingdaoyi.proto.model.tsl.TslModel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ResourceLock("ProtocolFactory.DECODERS")
+class ProtocolFactoryTest {
+
+    private Map<String, ProtocolDecoder> originalDecoders;
+
+    @BeforeEach
+    void snapshotDecoders() {
+        originalDecoders = new HashMap<>(ProtocolFactory.DECODERS);
+    }
+
+    @AfterEach
+    void restoreDecoders() {
+        ProtocolFactory.DECODERS.clear();
+        ProtocolFactory.DECODERS.putAll(originalDecoders);
+    }
+
+    @Test
+    void getDecoderReturnsRegisteredDecoderByProtocolKey() {
+        ProtocolDecoder decoder = new StubDecoder("demo-proto");
+        ProtocolFactory.DECODERS.put("demo-proto", decoder);
+
+        assertThat(ProtocolFactory.getDecoder("demo-proto")).containsSame(decoder);
+        assertThat(ProtocolFactory.getDecoder("missing-proto")).isEmpty();
+    }
+
+    @Test
+    void unloadProtocolRemovesExistingDecoderAndIsIdempotent() {
+        ProtocolDecoder decoder = new StubDecoder("demo-proto");
+        ProtocolFactory.DECODERS.put("demo-proto", decoder);
+
+        assertThat(ProtocolFactory.unloadProtocol("demo-proto")).isTrue();
+        assertThat(ProtocolFactory.getDecoder("demo-proto")).isEmpty();
+        assertThat(ProtocolFactory.unloadProtocol("demo-proto")).isTrue();
+    }
+
+    private record StubDecoder(String protocolKey) implements ProtocolDecoder {
+        @Override
+        public DecodeResult decode(DeviceRequest request, TslModel tslModel) {
+            return new DecodeResult();
+        }
+
+        @Override
+        public EncoderResult encode(EncoderMessage message, TslModel tslModel) {
+            return null;
+        }
+
+        @Override
+        public void responseError(DeviceConnection connection, ProtocolException e) {
+        }
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/rule/RuleChainEngineTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/rule/RuleChainEngineTest.java
@@ -1,0 +1,149 @@
+package com.github.dingdaoyi.rule;
+
+import com.github.dingdaoyi.entity.RuleChain;
+import com.github.dingdaoyi.entity.enu.RuleNodeType;
+import com.github.dingdaoyi.rule.config.NodeConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RuleChainEngineTest {
+
+    private RuleChainEngine engine;
+    private RecordingExecutor inputExecutor;
+    private RecordingExecutor trueExecutor;
+    private RecordingExecutor falseExecutor;
+    private RecordingExecutor outputExecutor;
+
+    @BeforeEach
+    void setUp() {
+        inputExecutor = new RecordingExecutor(RuleNodeType.INPUT_PROPERTY, RuleNodeExecutor.NodeResult.ok());
+        trueExecutor = new RecordingExecutor(RuleNodeType.FILTER_PROPERTY, RuleNodeExecutor.NodeResult.of(true, "matched", "unmatched"));
+        falseExecutor = new RecordingExecutor(RuleNodeType.FILTER_EVENT_TYPE, RuleNodeExecutor.NodeResult.of(false));
+        outputExecutor = new RecordingExecutor(RuleNodeType.OUTPUT_MESSAGE, RuleNodeExecutor.NodeResult.success("sent"));
+
+        engine = new RuleChainEngine();
+        ReflectionTestUtils.setField(engine, "executors", List.of(inputExecutor, trueExecutor, falseExecutor, outputExecutor));
+        engine.init();
+    }
+
+    @Test
+    void executeStartsFromInputNodesAndFollowsMatchingConnectionTypes() {
+        RuleChain ruleChain = enabledChain(
+            List.of(
+                node("input", RuleNodeType.INPUT_PROPERTY, "Input"),
+                node("filterTrue", RuleNodeType.FILTER_PROPERTY, "True Filter"),
+                node("filterFalse", RuleNodeType.FILTER_EVENT_TYPE, "False Filter"),
+                node("output", RuleNodeType.OUTPUT_MESSAGE, "Output")
+            ),
+            List.of(
+                connection("input", "filterTrue", "Success"),
+                connection("input", "filterFalse", "Failure"),
+                connection("filterTrue", "output", "True"),
+                connection("filterFalse", "output", "False")
+            )
+        );
+        RuleContext context = new RuleContext();
+
+        engine.execute(ruleChain, context);
+
+        assertThat(context.getRuleChainId()).isEqualTo(100);
+        assertThat(inputExecutor.executedNodeConfigs).hasSize(1);
+        assertThat(trueExecutor.executedNodeConfigs).hasSize(1);
+        assertThat(falseExecutor.executedNodeConfigs).isEmpty();
+        assertThat(outputExecutor.executedNodeConfigs).hasSize(1);
+        assertThat(context.getTraces())
+            .extracting(RuleContext.ExecutionTrace::getNodeId)
+            .containsExactly("input", "filterTrue", "output");
+        assertThat(context.getTraces())
+            .extracting(RuleContext.ExecutionTrace::getConnectionType)
+            .containsExactly("Success", "True", "Success");
+    }
+
+    @Test
+    void executeSkipsDisabledRuleChain() {
+        RuleChain ruleChain = enabledChain(List.of(node("input", RuleNodeType.INPUT_PROPERTY, "Input")), List.of());
+        ruleChain.setIsEnabled(false);
+
+        engine.execute(ruleChain, new RuleContext());
+
+        assertThat(inputExecutor.executedNodeConfigs).isEmpty();
+    }
+
+    @Test
+    void executeAddsFailureTraceWhenNodeExecutorThrows() {
+        RecordingExecutor throwingInput = new RecordingExecutor(RuleNodeType.INPUT_PROPERTY, RuleNodeExecutor.NodeResult.ok());
+        throwingInput.exception = new IllegalStateException("boom");
+        engine = new RuleChainEngine();
+        ReflectionTestUtils.setField(engine, "executors", List.of(throwingInput));
+        engine.init();
+        RuleChain ruleChain = enabledChain(List.of(node("input", RuleNodeType.INPUT_PROPERTY, "Input")), List.of());
+        RuleContext context = new RuleContext();
+
+        engine.execute(ruleChain, context);
+
+        assertThat(context.getTraces()).hasSize(1);
+        assertThat(context.getTraces().getFirst().getNodeId()).isEqualTo("input");
+        assertThat(context.getTraces().getFirst().getConnectionType()).isEqualTo("Failure");
+        assertThat(context.getTraces().getFirst().getDetail()).isEqualTo("boom");
+    }
+
+    private static RuleChain enabledChain(List<RuleChain.RuleNode> nodes, List<RuleChain.RuleConnection> connections) {
+        RuleChain ruleChain = new RuleChain();
+        ruleChain.setId(100);
+        ruleChain.setIsEnabled(true);
+        RuleChain.RuleChainConfiguration configuration = new RuleChain.RuleChainConfiguration();
+        configuration.setNodes(nodes);
+        configuration.setConnections(connections);
+        ruleChain.setConfiguration(configuration);
+        return ruleChain;
+    }
+
+    private static RuleChain.RuleNode node(String id, RuleNodeType type, String name) {
+        RuleChain.RuleNode node = new RuleChain.RuleNode();
+        node.setId(id);
+        node.setType(type.name());
+        node.setName(name);
+        node.setConfig(new NodeConfig() {});
+        return node;
+    }
+
+    private static RuleChain.RuleConnection connection(String source, String target, String type) {
+        RuleChain.RuleConnection connection = new RuleChain.RuleConnection();
+        connection.setSource(source);
+        connection.setTarget(target);
+        connection.setType(type);
+        return connection;
+    }
+
+    private static class RecordingExecutor implements RuleNodeExecutor {
+        private final RuleNodeType nodeType;
+        private final NodeResult result;
+        private final List<NodeConfig> executedNodeConfigs = new ArrayList<>();
+        private RuntimeException exception;
+
+        private RecordingExecutor(RuleNodeType nodeType, NodeResult result) {
+            this.nodeType = nodeType;
+            this.result = result;
+        }
+
+        @Override
+        public RuleNodeType getNodeType() {
+            return nodeType;
+        }
+
+        @Override
+        public NodeResult execute(RuleContext context, NodeConfig config) {
+            executedNodeConfigs.add(config);
+            if (exception != null) {
+                throw exception;
+            }
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add P0 unit coverage for RuleChainEngine execution paths and failure traces
- Add MQTT topic parsing tests and reject unknown MQTT message types instead of returning a topic with `null` messageType
- Add InfluxDataProcessor tests for product-scoped measurements, typed fields, and empty payload handling
- Add ProtocolFactory registry tests with static-state snapshot/restore and JUnit resource locks for parallel safety

## Test Plan
- [x] `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw -pl iot-server -Dtest=MqttTopicTest test`
- [x] `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw -pl iot-server -Dtest=RuleChainEngineTest test`
- [x] `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw -pl iot-server -Dtest=InfluxDataProcessorTest test`
- [x] `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw -pl iot-server -Dtest=MqttTopicTest,RuleChainEngineTest,InfluxDataProcessorTest,ProtocolFactoryTest test`
- [x] `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw -pl iot-server test`
- [x] `git diff --cached --check`
- [x] Codex final pre-commit review: `Blockers: none`

## Notes
- This addresses ROADMAP P0-1 test coverage for RuleEngine, MQTT ingress topic parsing, Influx data processing, and protocol decoder registry coverage.
