### PR TITLE
feat(api): publish OpenAPI docs

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -34,7 +34,7 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: 'Guide', link: '/guide/getting-started' },
-          { text: 'API', link: '/api/dict' },
+          { text: 'API', link: '/api/openapi' },
           { text: 'Live Demo', link: '/guide/demo' },
           { text: 'Changelog', link: 'https://github.com/dingdaoyi/simple-iot/blob/main/CHANGELOG.md' },
         ],
@@ -61,6 +61,7 @@ export default defineConfig({
             {
               text: 'REST API',
               items: [
+                { text: 'OpenAPI', link: '/api/openapi' },
                 { text: 'Dictionary Endpoints', link: '/api/dict' },
               ],
             },
@@ -75,7 +76,7 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: '指南', link: '/zh/guide/getting-started' },
-          { text: 'API', link: '/zh/api/dict' },
+          { text: 'API', link: '/zh/api/openapi' },
           { text: '在线演示', link: '/zh/guide/demo' },
           { text: '更新日志', link: 'https://github.com/dingdaoyi/simple-iot/blob/main/CHANGELOG.md' },
         ],
@@ -102,6 +103,7 @@ export default defineConfig({
             {
               text: 'REST API',
               items: [
+                { text: 'OpenAPI', link: '/zh/api/openapi' },
                 { text: '字典端点', link: '/zh/api/dict' },
               ],
             },

--- a/docs/api/openapi.md
+++ b/docs/api/openapi.md
@@ -1,0 +1,31 @@
+# OpenAPI
+
+Simple IoT exposes an OpenAPI 3.1 document and a hosted Swagger UI / Knife4j UI from the backend service.
+
+## Local endpoints
+
+When the backend runs with the default context path (`/iot`):
+
+| Resource | URL |
+|---|---|
+| OpenAPI JSON | `http://localhost:5010/iot/v3/api-docs` |
+| Swagger UI | `http://localhost:5010/iot/swagger-ui.html` |
+| Knife4j UI | `http://localhost:5010/iot/doc.html` |
+
+The documentation endpoints are intentionally excluded from the Sa-Token login interceptor so developers can inspect the API before signing in.
+
+## What is included
+
+The generated spec scans controller classes under:
+
+```text
+com.github.dingdaoyi.controller
+```
+
+This includes device, product, rule-chain, alarm, dictionary, user, notification, and file endpoints annotated with Swagger/OpenAPI metadata.
+
+## Notes
+
+- The spec version is OpenAPI `3.1.0`.
+- Runtime business endpoints still require authentication unless they are explicitly listed in the Sa-Token skip list.
+- The API document is generated at runtime from Spring MVC controllers; if you add a controller, annotate it with `@Tag` and each operation with `@Operation`.

--- a/docs/zh/api/openapi.md
+++ b/docs/zh/api/openapi.md
@@ -1,0 +1,31 @@
+# OpenAPI
+
+Simple IoT 后端会暴露 OpenAPI 3.1 文档，并提供 Swagger UI / Knife4j 在线调试入口。
+
+## 本地地址
+
+后端使用默认 context path（`/iot`）启动时：
+
+| 资源 | 地址 |
+|---|---|
+| OpenAPI JSON | `http://localhost:5010/iot/v3/api-docs` |
+| Swagger UI | `http://localhost:5010/iot/swagger-ui.html` |
+| Knife4j UI | `http://localhost:5010/iot/doc.html` |
+
+这些文档入口会从 Sa-Token 登录拦截器中放行，方便开发者在登录前查看 API 结构。
+
+## 覆盖范围
+
+生成的接口文档扫描以下 controller 包：
+
+```text
+com.github.dingdaoyi.controller
+```
+
+包括设备、产品、规则链、告警、字典、用户、消息通知、文件等已添加 Swagger/OpenAPI 注解的接口。
+
+## 约定
+
+- 规范版本为 OpenAPI `3.1.0`。
+- 运行时业务接口仍然需要认证，除非显式加入 Sa-Token 放行列表。
+- API 文档由 Spring MVC Controller 运行时生成；新增 Controller 时请补充 `@Tag` 和 `@Operation` 注解。

--- a/iot-server/src/main/java/com/github/dingdaoyi/config/openapi/OpenApiConfig.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/config/openapi/OpenApiConfig.java
@@ -1,0 +1,31 @@
+package com.github.dingdaoyi.config.openapi;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * OpenAPI documentation metadata.
+ */
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI simpleIotOpenApi() {
+        return new OpenAPI()
+            .openapi("3.1.0")
+            .info(new Info()
+                .title("Simple IoT API")
+                .version("0.1.0")
+                .description("Simple IoT is a one-jar IoT platform for device access, telemetry, rule chains, and operations dashboards.")
+                .contact(new Contact()
+                    .name("dingdaoyi")
+                    .url("https://github.com/dingdaoyi/simple-iot"))
+                .license(new License()
+                    .name("MIT")
+                    .url("https://github.com/dingdaoyi/simple-iot/blob/main/LICENSE")));
+    }
+}

--- a/iot-server/src/main/java/com/github/dingdaoyi/config/satoken/SaTokenConfigure.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/config/satoken/SaTokenConfigure.java
@@ -25,13 +25,14 @@ public class SaTokenConfigure implements WebMvcConfigurer {
 
     static {
         DEFAULT_SKIP_URL.add("/doc.html");
+        DEFAULT_SKIP_URL.add("/swagger-ui.html");
+        DEFAULT_SKIP_URL.add("/swagger-ui/**");
         DEFAULT_SKIP_URL.add("/v2/api-docs");
+        DEFAULT_SKIP_URL.add("/v3/api-docs");
         DEFAULT_SKIP_URL.add("/v3/api-docs/**");
         DEFAULT_SKIP_URL.add("/favicon.ico");
         DEFAULT_SKIP_URL.add("/error");
         DEFAULT_SKIP_URL.add("/static/**");
-        DEFAULT_SKIP_URL.add("/webjars*");
-        DEFAULT_SKIP_URL.add("/webjars*");
         DEFAULT_SKIP_URL.add("/webjars/**");
         DEFAULT_SKIP_URL.add("/swagger-resources/**");
     }

--- a/iot-server/src/test/java/com/github/dingdaoyi/config/openapi/OpenApiDocumentationTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/config/openapi/OpenApiDocumentationTest.java
@@ -1,0 +1,40 @@
+package com.github.dingdaoyi.config.openapi;
+
+import com.github.dingdaoyi.config.satoken.SaTokenConfigure;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenApiDocumentationTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void saTokenSkipsOpenApiAndSwaggerUiPublicDocumentationEndpoints() {
+        List<String> skipUrls = (List<String>) ReflectionTestUtils.getField(SaTokenConfigure.class, "DEFAULT_SKIP_URL");
+
+        assertThat(skipUrls)
+            .contains(
+                "/doc.html",
+                "/swagger-ui.html",
+                "/swagger-ui/**",
+                "/v3/api-docs",
+                "/v3/api-docs/**",
+                "/webjars/**",
+                "/swagger-resources/**"
+            );
+    }
+
+    @Test
+    void openApiBeanPublishesProjectMetadataAndUsesOpenApi31() {
+        OpenAPI openAPI = new OpenApiConfig().simpleIotOpenApi();
+
+        assertThat(openAPI.getOpenapi()).isEqualTo("3.1.0");
+        assertThat(openAPI.getInfo().getTitle()).isEqualTo("Simple IoT API");
+        assertThat(openAPI.getInfo().getVersion()).isEqualTo("0.1.0");
+        assertThat(openAPI.getInfo().getDescription()).contains("one-jar IoT platform");
+    }
+}


### PR DESCRIPTION
## Summary
- Add explicit OpenAPI 3.1 metadata for Simple IoT API
- Exclude Swagger UI, Knife4j, and `/v3/api-docs` endpoints from Sa-Token login interception
- Add focused tests for OpenAPI metadata and public docs skip paths
- Document OpenAPI JSON, Swagger UI, and Knife4j UI in English/Chinese VitePress docs

## Verification
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw -pl iot-server test`
- `pnpm docs:build`
- `git diff --cached --check`
