### PR TITLE
test(server): add PostgreSQL integration harness

### DIFF
--- a/iot-server/pom.xml
+++ b/iot-server/pom.xml
@@ -73,6 +73,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.influxdb</groupId>
             <artifactId>influxdb3-java</artifactId>
         </dependency>
@@ -191,6 +201,16 @@
                             <version>${lombok.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- OrbStack/Docker 29 rejects Docker API versions older than 1.40. -->
+                        <api.version>1.40</api.version>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/iot-server/src/test/java/com/github/dingdaoyi/integration/ApplicationPostgresIntegrationTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/integration/ApplicationPostgresIntegrationTest.java
@@ -1,0 +1,70 @@
+package com.github.dingdaoyi.integration;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@ActiveProfiles("integration")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ApplicationPostgresIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("simple")
+            .withUsername("postgres")
+            .withPassword(java.util.UUID.randomUUID().toString());
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", () -> postgres.getJdbcUrl() + "&sslmode=disable");
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @MockitoBean
+    private InfluxDBClient influxDBClient;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @LocalServerPort
+    private int port;
+
+    @Test
+    void startsApplicationAgainstRealPostgresAndPublishesOpenApiDocs() throws Exception {
+        Integer tableCount = jdbcTemplate.queryForObject(
+                "select count(*) from information_schema.tables where table_schema = 'public' and table_name = 'tb_user'",
+                Integer.class);
+
+        assertThat(tableCount).isEqualTo(1);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + "/iot/v3/api-docs"))
+                .GET()
+                .build();
+        HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isBetween(200, 299);
+        assertThat(response.body())
+                .contains("\"openapi\":\"3.1.0\"")
+                .contains("\"title\":\"Simple IoT API\"");
+    }
+}

--- a/iot-server/src/test/resources/application-integration.yml
+++ b/iot-server/src/test/resources/application-integration.yml
@@ -1,0 +1,28 @@
+spring:
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:integration/init-postgres.sql
+  datasource:
+    driver-class-name: org.postgresql.Driver
+  main:
+    lazy-initialization: false
+
+server:
+  port: 0
+
+mqtt:
+  server:
+    enabled: false
+
+sample:
+  iot:
+    storage-type: file
+    localstorage:
+      local-dir: ${java.io.tmpdir}/simple-iot-integration-upload
+    influxdb:
+      url: http://127.0.0.1:8086
+      token: ${SIMPLE_IOT_INTEGRATION_INFLUX_TOKEN:}
+      database: sample
+      prop-database: prop_data
+      event-database: event_data

--- a/iot-server/src/test/resources/integration/init-postgres.sql
+++ b/iot-server/src/test/resources/integration/init-postgres.sql
@@ -1,0 +1,57 @@
+CREATE TABLE tb_user (
+    id integer PRIMARY KEY,
+    username varchar(50) NOT NULL,
+    password varchar(255) NOT NULL,
+    enabled boolean NOT NULL DEFAULT true,
+    account_non_expired boolean NOT NULL DEFAULT true,
+    account_non_locked boolean NOT NULL DEFAULT true,
+    credentials_non_expired boolean NOT NULL DEFAULT true
+);
+
+CREATE TABLE sms_config (
+    id integer PRIMARY KEY,
+    name varchar(100) NOT NULL,
+    supplier varchar(50) NOT NULL,
+    access_key varchar(200) NOT NULL,
+    secret_key varchar(200) NOT NULL,
+    sign_name varchar(100),
+    template_id varchar(100),
+    endpoint varchar(200),
+    region varchar(50),
+    config_json text,
+    is_default boolean NOT NULL DEFAULT false,
+    status integer NOT NULL DEFAULT 1,
+    create_time timestamp,
+    update_time timestamp
+);
+
+CREATE TABLE tb_iot_driver (
+    driver_id integer PRIMARY KEY,
+    name varchar(100) NOT NULL,
+    type varchar(50) NOT NULL,
+    description varchar(255),
+    connection_type varchar(50),
+    jar_path varchar(255),
+    is_default boolean NOT NULL DEFAULT false,
+    status integer NOT NULL DEFAULT 1,
+    port integer NOT NULL
+);
+
+CREATE TABLE tb_protocol (
+    id integer PRIMARY KEY,
+    name varchar(50) NOT NULL,
+    proto_type smallint NOT NULL DEFAULT 2,
+    url varchar(255) NOT NULL DEFAULT '',
+    mark varchar(255) NOT NULL DEFAULT '',
+    proto_key varchar(50) NOT NULL,
+    handler_class varchar(255),
+    script_content text,
+    script_lang varchar(50),
+    status integer NOT NULL DEFAULT 1
+);
+
+INSERT INTO tb_iot_driver (driver_id, name, type, description, connection_type, jar_path, is_default, status, port)
+VALUES (1, 'Integration TCP Driver', 'TCP', 'Integration test driver', 'DEFAULT', NULL, false, 1, 1677);
+
+INSERT INTO tb_protocol (id, name, proto_type, url, mark, proto_key, handler_class, script_content, script_lang, status)
+VALUES (1, 'System Protocol', 2, '', 'Integration test protocol', 'system-default', 'com.github.dingdaoyi.iot.proto.defaul.DefaultProtocolDecoder', NULL, NULL, 1);

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <graalvm-js.version>24.1.1</graalvm-js.version>
         <groovy.version>4.0.24</groovy.version>
         <jython.version>2.7.4</jython.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -181,6 +182,20 @@
                 <groupId>org.python</groupId>
                 <artifactId>jython-standalone</artifactId>
                 <version>${jython.version}</version>
+            </dependency>
+
+            <!-- Integration testing -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${testcontainers.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${testcontainers.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary
- add Testcontainers PostgreSQL integration test for full Spring Boot web context startup
- verify the OpenAPI endpoint responds from the booted app
- add an integration profile with minimal PostgreSQL fixture data and mocked InfluxDB client
- pin Docker API version for Surefire so OrbStack/Docker 29 runs Testcontainers instead of skipping/failing discovery

## Verification
- JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw -pl iot-server -Dtest=ApplicationPostgresIntegrationTest test
- JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw -pl iot-server test
- JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw test