### PR TITLE
ci: run backend tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Build with Maven
-        run: mvn -B -ntp package --file pom.xml -DskipTests
+      - name: Test and build with Maven
+        run: mvn -B -ntp verify --file pom.xml
 
   frontend:
     name: 🎨 Frontend (Vue 3 · Vite)


### PR DESCRIPTION
## Summary
- replace backend CI package-with-skipTests with Maven verify
- ensure PR CI executes the existing unit and Testcontainers PostgreSQL integration tests

## Verification
- git diff --check
- JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw -B -ntp verify --file pom.xml

Promotion drafts are not included in this PR.