### PR TITLE
fix(server): redact MQTT auth secrets in logs

### DIFF
--- a/iot-server/src/main/java/com/github/dingdaoyi/driver/mqtt/MqttServerAuthHandler.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/driver/mqtt/MqttServerAuthHandler.java
@@ -29,7 +29,7 @@ public class MqttServerAuthHandler implements IMqttServerAuthHandler {
 
     @Override
     public boolean authenticate(ChannelContext context, String uniqueId, String clientId, String userName, String password) {
-        log.info("authenticate client {} user {} password {}", clientId, userName, password);
+        log.info("authenticate client {} user {} password {}", clientId, userName, maskSecret(password));
         if (ERROR_UNIQUE_ID.equals(uniqueId)) {
             return false;
         }
@@ -40,5 +40,15 @@ public class MqttServerAuthHandler implements IMqttServerAuthHandler {
                 .map(item -> (!iotConfigProperties.isEnableDeviceSecret())
                                           || StringUtils.equals(password, item.getDeviceSecret()))
                 .orElse(false);
+    }
+
+    static String maskSecret(String secret) {
+        if (StringUtils.isBlank(secret)) {
+            return "<empty>";
+        }
+        if (secret.length() <= 4) {
+            return "****";
+        }
+        return StringUtils.repeat('*', secret.length() - 4) + secret.substring(secret.length() - 4);
     }
 }

--- a/iot-server/src/test/java/com/github/dingdaoyi/driver/mqtt/MqttServerAuthHandlerTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/driver/mqtt/MqttServerAuthHandlerTest.java
@@ -1,0 +1,27 @@
+package com.github.dingdaoyi.driver.mqtt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MqttServerAuthHandlerTest {
+
+    @Test
+    void maskSecretKeepsOnlyLastFourCharacters() {
+        assertThat(MqttServerAuthHandler.maskSecret("device-secret-1234"))
+                .isEqualTo("**************1234");
+    }
+
+    @Test
+    void maskSecretHidesShortSecretsCompletely() {
+        assertThat(MqttServerAuthHandler.maskSecret("1234")).isEqualTo("****");
+        assertThat(MqttServerAuthHandler.maskSecret("123")).isEqualTo("****");
+    }
+
+    @Test
+    void maskSecretHandlesBlankValues() {
+        assertThat(MqttServerAuthHandler.maskSecret(null)).isEqualTo("<empty>");
+        assertThat(MqttServerAuthHandler.maskSecret("")).isEqualTo("<empty>");
+        assertThat(MqttServerAuthHandler.maskSecret("   ")).isEqualTo("<empty>");
+    }
+}


### PR DESCRIPTION
## Summary
- stop logging raw MQTT device passwords during authentication
- add a small redaction helper that keeps only the last 4 characters for diagnostics
- cover blank, short, and regular secrets with unit tests

## Verification
- JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw -pl iot-server -Dtest=MqttServerAuthHandlerTest test
- git diff --check

## Security
- no raw device secret is logged by the MQTT auth handler after this change