### PR TITLE
feat(web): reset alarm filters

### DIFF
--- a/iot-web/src/views/alarm/index.vue
+++ b/iot-web/src/views/alarm/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Bell, Check, Close, View } from '@element-plus/icons-vue'
+import { Bell, Check, Close, RefreshRight, View } from '@element-plus/icons-vue'
 import { ElMessage } from 'element-plus'
 import { computed, onMounted, ref } from 'vue'
 import {
@@ -81,6 +81,7 @@ const {
   params,
   updatePage,
   onSearch,
+  onReset,
   tableData,
   total,
   loading,
@@ -340,6 +341,9 @@ onMounted(() => {
           <el-button type="primary" @click="onSearch">
             <span class="btn-icon">⌕</span>
             搜索
+          </el-button>
+          <el-button :icon="RefreshRight" @click="onReset">
+            重置
           </el-button>
         </div>
       </el-form>


### PR DESCRIPTION
## Summary
- add a reset action to the alarm search form
- clear alarm filters and reload the alarm list through the shared table composable

## Verification
- CI=true ./node_modules/.bin/eslint src/views/alarm/index.vue
- CI=true corepack pnpm build
- git diff --check