### PR TITLE
feat(web): reset product filters

### DIFF
--- a/iot-web/src/views/product/index.vue
+++ b/iot-web/src/views/product/index.vue
@@ -7,6 +7,7 @@ import {
   List,
   Monitor,
   Plus,
+  RefreshRight,
   Search,
   Setting,
 } from '@element-plus/icons-vue'
@@ -27,6 +28,7 @@ const {
   dialogVisible,
   updatePage,
   onSearch,
+  onReset,
   tableData,
   total,
   loading,
@@ -193,6 +195,9 @@ onMounted(() => {
           <el-button type="primary" @click="onSearch">
             <el-icon><Search /></el-icon>
             搜索
+          </el-button>
+          <el-button :icon="RefreshRight" @click="onReset">
+            重置
           </el-button>
           <el-button type="primary" @click="onAdd">
             <el-icon><Plus /></el-icon>


### PR DESCRIPTION
## Summary
- add a reset action to the product search bar
- clear product type, model, and manufacturer filters using the shared table reset helper
- keep product, device, alarm, and product type list interactions consistent

## Verification
- CI=true ./node_modules/.bin/eslint src/views/product/index.vue
- CI=true corepack pnpm build
- git diff --check