### PR TITLE
feat(web): reset push config filters

### DIFF
--- a/iot-web/src/views/push-config/index.vue
+++ b/iot-web/src/views/push-config/index.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { RefreshRight } from '@element-plus/icons-vue'
 import { onMounted } from 'vue'
 import { pushConfigDeleteApi, pushConfigPageApi } from '@/api/index.js'
 import IotTable from '@/components/IotTable.vue'
@@ -63,6 +64,7 @@ const {
   dialogVisible,
   updatePage,
   onSearch,
+  onReset,
   tableData,
   total,
   loading,
@@ -148,6 +150,9 @@ onMounted(() => {
         <div class="search-actions">
           <el-button type="primary" @click="onSearch">
             搜索
+          </el-button>
+          <el-button :icon="RefreshRight" @click="onReset">
+            重置
           </el-button>
           <el-button type="primary" @click="onAdd">
             添加配置


### PR DESCRIPTION
## Summary
- add a reset action to the push config search bar
- clear name, type, and enabled filters with the shared table reset helper
- keep filtering behavior consistent across management pages

## Verification
- CI=true ./node_modules/.bin/eslint src/views/push-config/index.vue
- CI=true corepack pnpm build
- git diff --check