### PR TITLE
feat(web): reset message receive filters

### DIFF
--- a/iot-web/src/views/system/messageReceive/index.vue
+++ b/iot-web/src/views/system/messageReceive/index.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { RefreshRight } from '@element-plus/icons-vue'
 import { onMounted } from 'vue'
 import { messageReceiveDeleteApi, messageReceivePageApi } from '@/api/index.js'
 import IotTable from '@/components/IotTable.vue'
@@ -51,6 +52,7 @@ const {
   dialogVisible,
   updatePage,
   onSearch,
+  onReset,
   tableData,
   total,
   loading,
@@ -115,6 +117,9 @@ onMounted(() => {
         <div class="search-actions">
           <el-button type="primary" @click="onSearch">
             搜索
+          </el-button>
+          <el-button :icon="RefreshRight" @click="onReset">
+            重置
           </el-button>
           <el-button type="primary" @click="onAdd">
             添加通知


### PR DESCRIPTION
## Summary
- add a reset action to the message receive search bar
- clear notification type filters with the shared table reset helper

## Verification
- CI=true ./node_modules/.bin/eslint src/views/system/messageReceive/index.vue
- CI=true corepack pnpm build
- git diff --check