### PR TITLE
fix(web): align message receive actions

### DIFF
--- a/iot-web/src/views/system/messageReceive/index.vue
+++ b/iot-web/src/views/system/messageReceive/index.vue
@@ -141,11 +141,11 @@ onMounted(() => {
         @size-change="onSizeChange"
       >
         <template #cz="{ row }">
-          <el-button type="danger" link @click="onDelete(row)">
-            删除
-          </el-button>
           <el-button type="primary" link @click="onEdit(row)">
             编辑
+          </el-button>
+          <el-button type="danger" link @click="onDelete(row)">
+            删除
           </el-button>
         </template>
       </IotTable>


### PR DESCRIPTION
## Summary
- move the edit action before delete in message receive rows
- align destructive action placement with other management tables

## Verification
- CI=true ./node_modules/.bin/eslint src/views/system/messageReceive/index.vue
- CI=true corepack pnpm build
- git diff --check