### PR TITLE
fix(web): align property actions

### DIFF
--- a/iot-web/src/views/tslModel/widget/property.vue
+++ b/iot-web/src/views/tslModel/widget/property.vue
@@ -85,11 +85,11 @@ const {
       :api="propertyListApi"
     >
       <template #cz="{ row }">
-        <el-button v-if="showEdite" type="danger" link @click="onDelete(row)">
-          删除
-        </el-button>
         <el-button v-if="showEdite" type="primary" link @click="onEdit(row)">
           编辑定义
+        </el-button>
+        <el-button v-if="showEdite" type="danger" link @click="onDelete(row)">
+          删除
         </el-button>
       </template>
     </IotTable>


### PR DESCRIPTION
## Summary
- move edit definition before delete in the TSL property table
- align destructive action placement with the rest of the management UI

## Verification
- CI=true ./node_modules/.bin/eslint src/views/tslModel/widget/property.vue
- CI=true corepack pnpm build
- git diff --check