### PR TITLE
feat(web): search product types on enter

### DIFF
--- a/iot-web/src/views/productType/index.vue
+++ b/iot-web/src/views/productType/index.vue
@@ -111,6 +111,7 @@ function tslConfig(row) {
             clearable
             placeholder="输入产品类型名称搜索..."
             prefix-icon="Search"
+            @keyup.enter="onSearch"
           />
         </div>
         <div class="search-actions">


### PR DESCRIPTION
## Summary
- trigger product type search when pressing Enter in the name field
- align the page with other keyboard-friendly search forms

## Verification
- CI=true ./node_modules/.bin/eslint src/views/productType/index.vue
- CI=true corepack pnpm build
- git diff --check