### PR TITLE
feat(web): support enter key in search fields

### DIFF
--- a/iot-web/src/views/alarm/index.vue
+++ b/iot-web/src/views/alarm/index.vue
@@ -307,11 +307,11 @@ onMounted(() => {
       <el-form :inline="false" class="search-form">
         <div class="form-row">
           <el-form-item label="设备Key">
-            <el-input v-model="params.deviceKey" clearable placeholder="请输入设备Key" />
+            <el-input v-model="params.deviceKey" clearable placeholder="请输入设备Key" @keyup.enter="onSearch" />
           </el-form-item>
 
           <el-form-item label="告警类型">
-            <el-input v-model="params.alarmType" clearable placeholder="请输入告警类型" />
+            <el-input v-model="params.alarmType" clearable placeholder="请输入告警类型" @keyup.enter="onSearch" />
           </el-form-item>
 
           <el-form-item label="严重程度">

--- a/iot-web/src/views/device/index.vue
+++ b/iot-web/src/views/device/index.vue
@@ -209,7 +209,7 @@ onMounted(() => {
           </el-form-item>
 
           <el-form-item label="设备编号">
-            <el-input v-model="params.deviceKey" clearable placeholder="输入设备编号" />
+            <el-input v-model="params.deviceKey" clearable placeholder="输入设备编号" @keyup.enter="onSearch" />
           </el-form-item>
         </div>
 

--- a/iot-web/src/views/protocol/index.vue
+++ b/iot-web/src/views/protocol/index.vue
@@ -202,6 +202,7 @@ onMounted(() => {
               clearable
               placeholder="输入协议名称"
               style="width: 200px"
+              @keyup.enter="onSearch"
             />
           </el-form-item>
 
@@ -211,6 +212,7 @@ onMounted(() => {
               clearable
               placeholder="输入协议 Key"
               style="width: 180px"
+              @keyup.enter="onSearch"
             />
           </el-form-item>
         </div>

--- a/iot-web/src/views/push-config/index.vue
+++ b/iot-web/src/views/push-config/index.vue
@@ -116,6 +116,7 @@ onMounted(() => {
             placeholder="请输入配置名称"
             clearable
             style="width: 200px"
+            @keyup.enter="onSearch"
           />
         </div>
         <div class="search-field">

--- a/iot-web/src/views/rule-chain/index.vue
+++ b/iot-web/src/views/rule-chain/index.vue
@@ -146,7 +146,7 @@ onMounted(() => {
       <el-form :inline="false" class="search-form">
         <div class="form-row">
           <el-form-item label="规则名称">
-            <el-input v-model="params.name" clearable placeholder="请输入规则名称" />
+            <el-input v-model="params.name" clearable placeholder="请输入规则名称" @keyup.enter="onSearch" />
           </el-form-item>
 
           <el-form-item label="数据源类型">

--- a/iot-web/src/views/tslModel/widget/property.vue
+++ b/iot-web/src/views/tslModel/widget/property.vue
@@ -67,7 +67,7 @@ const {
   <div class="wh-full">
     <div class="flex flex-row mb-12px">
       <div class="w-240px mr-12px">
-        <el-input v-model="params.search" clearable placeholder="请输入属性名称或标识符搜索" />
+        <el-input v-model="params.search" clearable placeholder="请输入属性名称或标识符搜索" @keyup.enter="onSearch" />
       </div>
       <el-button type="primary" @click="onSearch">
         搜索

--- a/iot-web/src/views/tslModel/widget/service.vue
+++ b/iot-web/src/views/tslModel/widget/service.vue
@@ -130,7 +130,7 @@ loadPropertiesDict()
   <div class="wh-full">
     <div class="flex flex-row mb-12px">
       <div class="w-240px mr-12px">
-        <el-input v-model="params.search" clearable placeholder="请输入服务名称或标识符搜索" />
+        <el-input v-model="params.search" clearable placeholder="请输入服务名称或标识符搜索" @keyup.enter="onSearch" />
       </div>
       <ElButton type="primary" @click="onSearch">
         搜索


### PR DESCRIPTION
## Summary
- add Enter-to-search support to text filters across alarm, device, protocol, push config, rule chain, and TSL pages
- keep select/date-only filters unchanged to avoid interfering with picker keyboard behavior
- batch the same interaction improvement into one PR

## Verification
- CI=true ./node_modules/.bin/eslint src/views/alarm/index.vue src/views/device/index.vue src/views/protocol/index.vue src/views/push-config/index.vue src/views/rule-chain/index.vue src/views/tslModel/widget/property.vue src/views/tslModel/widget/service.vue
- CI=true corepack pnpm build
- git diff --check