### PR TITLE
feat(web): align table action buttons

### DIFF
--- a/iot-web/src/views/device/index.vue
+++ b/iot-web/src/views/device/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Cpu, RefreshRight } from '@element-plus/icons-vue'
+import { Cpu, Delete, Edit, Monitor, RefreshRight } from '@element-plus/icons-vue'
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { deviceDeleteApi, devicePageApi, manufacturerListApi, productListApi, productTypeListApi } from '@/api/index.js'
@@ -242,13 +242,13 @@ onMounted(() => {
         @size-change="onSizeChange"
       >
         <template #cz="{ row }">
-          <el-button type="primary" link @click="showDetails(row)">
+          <el-button type="primary" link :icon="Monitor" @click="showDetails(row)">
             设备详情
           </el-button>
-          <el-button type="primary" link @click="onEdit(row)">
+          <el-button type="primary" link :icon="Edit" @click="onEdit(row)">
             编辑
           </el-button>
-          <el-button type="danger" link @click="onDelete(row)">
+          <el-button type="danger" link :icon="Delete" @click="onDelete(row)">
             删除
           </el-button>
         </template>

--- a/iot-web/src/views/product/index.vue
+++ b/iot-web/src/views/product/index.vue
@@ -335,16 +335,16 @@ onMounted(() => {
         </template>
 
         <template #cz="{ row }">
-          <el-button type="primary" link @click="tslConfig(row)">
+          <el-button type="primary" link :icon="Setting" @click="tslConfig(row)">
             功能配置
           </el-button>
-          <el-button type="primary" link @click="onEdit(row)">
+          <el-button type="primary" link :icon="Edit" @click="onEdit(row)">
             编辑
           </el-button>
-          <el-button v-if="row.parentId === -1" type="primary" link @click="onAddChild(row)">
+          <el-button v-if="row.parentId === -1" type="primary" link :icon="Plus" @click="onAddChild(row)">
             添加子级
           </el-button>
-          <el-button type="danger" link @click="onDelete(row)">
+          <el-button type="danger" link :icon="Delete" @click="onDelete(row)">
             删除
           </el-button>
         </template>

--- a/iot-web/src/views/productType/index.vue
+++ b/iot-web/src/views/productType/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { RefreshRight } from '@element-plus/icons-vue'
+import { Delete, Edit, Plus, RefreshRight, Setting } from '@element-plus/icons-vue'
 import { nextTick, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { productTypeDelApi, productTypeListApi } from '@/api/index.js'
@@ -162,16 +162,16 @@ function tslConfig(row) {
         </template>
 
         <template #cz="{ row }">
-          <el-button type="primary" link @click="tslConfig(row)">
+          <el-button type="primary" link :icon="Setting" @click="tslConfig(row)">
             功能配置
           </el-button>
-          <el-button type="primary" link @click="onEdit(row)">
+          <el-button type="primary" link :icon="Edit" @click="onEdit(row)">
             编辑
           </el-button>
-          <el-button v-if="row.parentId === -1" type="primary" link @click="onAddChild(row)">
+          <el-button v-if="row.parentId === -1" type="primary" link :icon="Plus" @click="onAddChild(row)">
             添加子级
           </el-button>
-          <el-button type="danger" link @click="onDelete(row)">
+          <el-button type="danger" link :icon="Delete" @click="onDelete(row)">
             删除
           </el-button>
         </template>

--- a/iot-web/src/views/push-config/index.vue
+++ b/iot-web/src/views/push-config/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { RefreshRight } from '@element-plus/icons-vue'
+import { Delete, Edit, RefreshRight } from '@element-plus/icons-vue'
 import { onMounted } from 'vue'
 import { pushConfigDeleteApi, pushConfigPageApi } from '@/api/index.js'
 import IotTable from '@/components/IotTable.vue'
@@ -180,10 +180,10 @@ onMounted(() => {
           </el-tag>
         </template>
         <template #cz="{ row }">
-          <el-button type="primary" link @click="onEdit(row)">
+          <el-button type="primary" link :icon="Edit" @click="onEdit(row)">
             编辑
           </el-button>
-          <el-button type="danger" link @click="onDelete(row)">
+          <el-button type="danger" link :icon="Delete" @click="onDelete(row)">
             删除
           </el-button>
         </template>

--- a/iot-web/src/views/system/messageReceive/index.vue
+++ b/iot-web/src/views/system/messageReceive/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { RefreshRight } from '@element-plus/icons-vue'
+import { Delete, Edit, RefreshRight } from '@element-plus/icons-vue'
 import { onMounted } from 'vue'
 import { messageReceiveDeleteApi, messageReceivePageApi } from '@/api/index.js'
 import IotTable from '@/components/IotTable.vue'
@@ -141,10 +141,10 @@ onMounted(() => {
         @size-change="onSizeChange"
       >
         <template #cz="{ row }">
-          <el-button type="primary" link @click="onEdit(row)">
+          <el-button type="primary" link :icon="Edit" @click="onEdit(row)">
             编辑
           </el-button>
-          <el-button type="danger" link @click="onDelete(row)">
+          <el-button type="danger" link :icon="Delete" @click="onDelete(row)">
             删除
           </el-button>
         </template>

--- a/iot-web/src/views/tslModel/widget/property.vue
+++ b/iot-web/src/views/tslModel/widget/property.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { Delete, Edit } from '@element-plus/icons-vue'
 import { propertyDeleteApi, propertyListApi } from '@/api/index.js'
 import IotTable from '@/components/IotTable.vue'
 import { useTable } from '@/composables/useTable.js'
@@ -85,10 +86,10 @@ const {
       :api="propertyListApi"
     >
       <template #cz="{ row }">
-        <el-button v-if="showEdite" type="primary" link @click="onEdit(row)">
+        <el-button v-if="showEdite" type="primary" link :icon="Edit" @click="onEdit(row)">
           编辑定义
         </el-button>
-        <el-button v-if="showEdite" type="danger" link @click="onDelete(row)">
+        <el-button v-if="showEdite" type="danger" link :icon="Delete" @click="onDelete(row)">
           删除
         </el-button>
       </template>

--- a/iot-web/src/views/tslModel/widget/service.vue
+++ b/iot-web/src/views/tslModel/widget/service.vue
@@ -1,4 +1,5 @@
 <script lang="jsx" setup>
+import { Delete, Edit } from '@element-plus/icons-vue'
 import { ElButton, ElMessage, ElMessageBox } from 'element-plus'
 import { h, ref } from 'vue'
 import {
@@ -148,11 +149,11 @@ loadPropertiesDict()
       :api="productId ? customServiceListApi : standardServiceListApi"
     >
       <template #cz="{ row }">
-        <ElButton v-if="showEdite" type="danger" link @click="handleDelete(row)">
-          删除
-        </ElButton>
-        <ElButton v-if="showEdite" type="primary" link @click="onEdit(row)">
+        <ElButton v-if="showEdite" type="primary" link :icon="Edit" @click="onEdit(row)">
           编辑定义
+        </ElButton>
+        <ElButton v-if="showEdite" type="danger" link :icon="Delete" @click="handleDelete(row)">
+          删除
         </ElButton>
       </template>
     </IotTable>


### PR DESCRIPTION
## Summary
- add consistent icons to edit/delete/detail/config row actions across management pages
- keep destructive delete actions after edit actions
- batch the same table action polish into one PR

## Verification
- CI=true ./node_modules/.bin/eslint src/views/device/index.vue src/views/product/index.vue src/views/productType/index.vue src/views/push-config/index.vue src/views/system/messageReceive/index.vue src/views/tslModel/widget/property.vue src/views/tslModel/widget/service.vue
- CI=true corepack pnpm build
- git diff --check
- scan confirmed no delete-before-edit rows in table operation slots