### PR TITLE
feat(web): reset widget search filters

### DIFF
--- a/iot-web/src/views/device/widget/deviceEvent.vue
+++ b/iot-web/src/views/device/widget/deviceEvent.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { RefreshRight } from '@element-plus/icons-vue'
 import { computed, ref } from 'vue'
 import { deviceEventLogsApi } from '@/api/index.js'
 import IotTable from '@/components/IotTable.vue'
@@ -49,6 +50,7 @@ const column = [
 const {
   params,
   onSearch,
+  onReset,
   dwTable,
 } = useTable({
   defParams: {
@@ -65,6 +67,11 @@ function handleDateChange(val) {
     params.beginTime = DateUtils.formatDate(val[0])
     params.endTime = DateUtils.formatDate(val[1])
   }
+}
+
+function resetFilters() {
+  dateRange.value = [DateUtils.getStartOfDay(), DateUtils.getEndOfDay()]
+  onReset()
 }
 </script>
 
@@ -105,6 +112,9 @@ function handleDateChange(val) {
 
       <el-button type="primary" @click="onSearch">
         搜索
+      </el-button>
+      <el-button :icon="RefreshRight" @click="resetFilters">
+        重置
       </el-button>
     </div>
 

--- a/iot-web/src/views/tslModel/widget/property.vue
+++ b/iot-web/src/views/tslModel/widget/property.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Delete, Edit } from '@element-plus/icons-vue'
+import { Delete, Edit, RefreshRight } from '@element-plus/icons-vue'
 import { propertyDeleteApi, propertyListApi } from '@/api/index.js'
 import IotTable from '@/components/IotTable.vue'
 import { useTable } from '@/composables/useTable.js'
@@ -48,6 +48,7 @@ const {
   dialogVisible,
   updatePage,
   onSearch,
+  onReset,
   dwTable,
   onDelete,
   onEdit,
@@ -72,6 +73,9 @@ const {
       </div>
       <el-button type="primary" @click="onSearch">
         搜索
+      </el-button>
+      <el-button :icon="RefreshRight" @click="onReset">
+        重置
       </el-button>
       <el-button v-if="showEdite" type="primary" @click="onAdd">
         添加

--- a/iot-web/src/views/tslModel/widget/service.vue
+++ b/iot-web/src/views/tslModel/widget/service.vue
@@ -1,5 +1,5 @@
 <script lang="jsx" setup>
-import { Delete, Edit } from '@element-plus/icons-vue'
+import { Delete, Edit, RefreshRight } from '@element-plus/icons-vue'
 import { ElButton, ElMessage, ElMessageBox } from 'element-plus'
 import { h, ref } from 'vue'
 import {
@@ -102,6 +102,7 @@ const {
   params,
   dialogVisible,
   onSearch,
+  onReset,
   onEdit,
   onAdd,
   diaTitle,
@@ -135,6 +136,9 @@ loadPropertiesDict()
       </div>
       <ElButton type="primary" @click="onSearch">
         搜索
+      </ElButton>
+      <ElButton :icon="RefreshRight" @click="onReset">
+        重置
       </ElButton>
       <ElButton v-if="showEdite" type="primary" @click="onAdd">
         添加


### PR DESCRIPTION
## Summary
- add reset buttons to device event, TSL property, and TSL service lightweight search areas
- keep device event reset synchronized with its default date range
- verify no remaining onSearch widgets lack a reset entry point

## Verification
- CI=true ./node_modules/.bin/eslint src/views/device/widget/deviceEvent.vue src/views/tslModel/widget/property.vue src/views/tslModel/widget/service.vue
- CI=true corepack pnpm build
- git diff --check
- scan confirmed no onSearch widget/search area without reset