### PR TITLE
feat(push-config): validate delivery settings

### DIFF
--- a/iot-server/src/main/java/com/github/dingdaoyi/service/impl/PushConfigServiceImpl.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/impl/PushConfigServiceImpl.java
@@ -1,10 +1,14 @@
 package com.github.dingdaoyi.service.impl;
 
 import cn.hutool.core.bean.BeanUtil;
+import cn.hutool.core.util.StrUtil;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import com.github.dingdaoyi.core.base.PageResult;
+import com.github.dingdaoyi.core.enums.ResultCode;
+import com.github.dingdaoyi.core.exception.BusinessException;
 import com.github.dingdaoyi.entity.PushConfig;
+import com.github.dingdaoyi.entity.enu.PushConfigType;
 import com.github.dingdaoyi.mapper.PushConfigMapper;
 import com.github.dingdaoyi.model.query.PushConfigPageQuery;
 import com.github.dingdaoyi.model.vo.PushConfigDetailVo;
@@ -22,6 +26,100 @@ import java.util.Optional;
  */
 @Service
 public class PushConfigServiceImpl extends ServiceImpl<PushConfigMapper, PushConfig> implements PushConfigService {
+
+    @Override
+    public boolean save(PushConfig entity) {
+        validateAndNormalize(entity);
+        return super.save(entity);
+    }
+
+    @Override
+    public boolean updateById(PushConfig entity) {
+        validateAndNormalize(entity);
+        return super.updateById(entity);
+    }
+
+    private void validateAndNormalize(PushConfig config) {
+        if (config.getType() == PushConfigType.HTTP) {
+            validateHttpConfig(config);
+            clearMqttConfig(config);
+            return;
+        }
+        if (config.getType() == PushConfigType.MQTT) {
+            validateMqttConfig(config);
+            clearHttpConfig(config);
+            return;
+        }
+        throw new BusinessException(ResultCode.BAD_REQUEST, "配置类型不支持");
+    }
+
+    private void validateHttpConfig(PushConfig config) {
+        String httpUrl = StrUtil.trim(config.getHttpUrl());
+        if (StrUtil.isBlank(httpUrl)) {
+            throw new BusinessException(ResultCode.BAD_REQUEST, "HTTP请求URL不能为空");
+        }
+        if (!StrUtil.startWithIgnoreCase(httpUrl, "http://") && !StrUtil.startWithIgnoreCase(httpUrl, "https://")) {
+            throw new BusinessException(ResultCode.BAD_REQUEST, "HTTP请求URL必须以 http:// 或 https:// 开头");
+        }
+        config.setHttpUrl(httpUrl);
+        config.setHttpMethod(StrUtil.blankToDefault(StrUtil.trim(config.getHttpMethod()), "POST").toUpperCase());
+        if (config.getHttpTimeout() == null) {
+            config.setHttpTimeout(5000);
+        }
+    }
+
+    private void validateMqttConfig(PushConfig config) {
+        String broker = StrUtil.trim(config.getMqttBroker());
+        String topic = StrUtil.trim(config.getMqttTopic());
+        if (StrUtil.isBlank(broker)) {
+            throw new BusinessException(ResultCode.BAD_REQUEST, "MQTT Broker地址不能为空");
+        }
+        if (!StrUtil.startWithAnyIgnoreCase(broker, "tcp://", "ssl://", "ws://", "wss://")) {
+            throw new BusinessException(ResultCode.BAD_REQUEST, "MQTT Broker地址必须以 tcp://、ssl://、ws:// 或 wss:// 开头");
+        }
+        if (StrUtil.isBlank(topic)) {
+            throw new BusinessException(ResultCode.BAD_REQUEST, "MQTT目标Topic不能为空");
+        }
+        if (StrUtil.containsAny(topic, '#', '+')) {
+            throw new BusinessException(ResultCode.BAD_REQUEST, "MQTT发布Topic不能包含通配符 # 或 +");
+        }
+        config.setMqttBroker(broker);
+        config.setMqttTopic(topic);
+        config.setMqttUsername(StrUtil.trim(config.getMqttUsername()));
+        config.setMqttClientId(StrUtil.trim(config.getMqttClientId()));
+        if (config.getMqttQos() == null) {
+            config.setMqttQos(0);
+        }
+        if (config.getMqttKeepAlive() == null) {
+            config.setMqttKeepAlive(60);
+        }
+        if (config.getMqttRetain() == null) {
+            config.setMqttRetain(false);
+        }
+        if (config.getMqttCleanSession() == null) {
+            config.setMqttCleanSession(true);
+        }
+    }
+
+    private void clearHttpConfig(PushConfig config) {
+        config.setHttpUrl(null);
+        config.setHttpMethod("POST");
+        config.setHttpHeaders(List.of());
+        config.setHttpTimeout(5000);
+    }
+
+    private void clearMqttConfig(PushConfig config) {
+        config.setMqttBroker(null);
+        config.setMqttUsername(null);
+        config.setMqttPassword(null);
+        config.setMqttClientId(null);
+        config.setMqttTopic(null);
+        config.setMqttQos(0);
+        config.setMqttRetain(false);
+        config.setMqttKeepAlive(60);
+        config.setMqttCleanSession(true);
+        config.setMqttOptions(List.of());
+    }
 
     @Override
     public PageResult<PushConfigPageVo> pageByQuery(PushConfigPageQuery query) {

--- a/iot-server/src/test/java/com/github/dingdaoyi/service/PushConfigServiceTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/service/PushConfigServiceTest.java
@@ -1,0 +1,138 @@
+package com.github.dingdaoyi.service;
+
+import com.github.dingdaoyi.core.exception.BusinessException;
+import com.github.dingdaoyi.entity.PushConfig;
+import com.github.dingdaoyi.entity.enu.PushConfigType;
+import com.github.dingdaoyi.mapper.PushConfigMapper;
+import com.github.dingdaoyi.service.impl.PushConfigServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 推送配置服务测试
+ * @author dingyunwei
+ */
+@ExtendWith(MockitoExtension.class)
+class PushConfigServiceTest {
+
+    @Mock
+    private PushConfigMapper pushConfigMapper;
+
+    private PushConfigServiceImpl pushConfigService;
+
+    @BeforeEach
+    void setUp() {
+        pushConfigService = new PushConfigServiceImpl();
+        ReflectionTestUtils.setField(pushConfigService, "baseMapper", pushConfigMapper);
+    }
+
+    @Test
+    void saveRejectsHttpConfigWithoutHttpUrl() {
+        PushConfig config = baseConfig(PushConfigType.HTTP);
+        config.setHttpUrl("   ");
+
+        assertThatThrownBy(() -> pushConfigService.save(config))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("HTTP请求URL不能为空");
+    }
+
+    @Test
+    void saveRejectsHttpConfigWithUnsupportedUrlScheme() {
+        PushConfig config = baseConfig(PushConfigType.HTTP);
+        config.setHttpUrl("ftp://example.com/callback");
+
+        assertThatThrownBy(() -> pushConfigService.save(config))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("HTTP请求URL必须以 http:// 或 https:// 开头");
+    }
+
+    @Test
+    void saveNormalizesHttpConfigAndClearsMqttFields() {
+        PushConfig config = baseConfig(PushConfigType.HTTP);
+        config.setHttpUrl("  https://example.com/callback  ");
+        config.setHttpMethod("post");
+        config.setHttpTimeout(null);
+        config.setMqttBroker("tcp://localhost:1883");
+        config.setMqttTopic("device/up");
+        config.setMqttQos(1);
+        config.setMqttOptions(List.of(new PushConfig.KeyValue()));
+        when(pushConfigMapper.insert(config)).thenReturn(1);
+
+        pushConfigService.save(config);
+
+        ArgumentCaptor<PushConfig> captor = ArgumentCaptor.forClass(PushConfig.class);
+        verify(pushConfigMapper).insert(captor.capture());
+        PushConfig saved = captor.getValue();
+        assertThat(saved.getHttpUrl()).isEqualTo("https://example.com/callback");
+        assertThat(saved.getHttpMethod()).isEqualTo("POST");
+        assertThat(saved.getHttpTimeout()).isEqualTo(5000);
+        assertThat(saved.getMqttBroker()).isNull();
+        assertThat(saved.getMqttTopic()).isNull();
+        assertThat(saved.getMqttOptions()).isEmpty();
+    }
+
+    @Test
+    void updateRejectsMqttConfigWithWildcardPublishTopic() {
+        PushConfig config = baseConfig(PushConfigType.MQTT);
+        config.setId(1);
+        config.setMqttBroker("tcp://localhost:1883");
+        config.setMqttTopic("device/+/up");
+
+        assertThatThrownBy(() -> pushConfigService.updateById(config))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("MQTT发布Topic不能包含通配符");
+    }
+
+    @Test
+    void updateNormalizesMqttConfigAndClearsHttpFields() {
+        PushConfig config = baseConfig(PushConfigType.MQTT);
+        config.setId(1);
+        config.setMqttBroker("  tcp://localhost:1883  ");
+        config.setMqttTopic("  device/up  ");
+        config.setMqttUsername("  user  ");
+        config.setMqttClientId("  client-1  ");
+        config.setMqttQos(null);
+        config.setMqttRetain(null);
+        config.setMqttKeepAlive(null);
+        config.setMqttCleanSession(null);
+        config.setHttpUrl("https://example.com/callback");
+        config.setHttpHeaders(List.of(new PushConfig.KeyValue()));
+        when(pushConfigMapper.updateById(config)).thenReturn(1);
+
+        pushConfigService.updateById(config);
+
+        ArgumentCaptor<PushConfig> captor = ArgumentCaptor.forClass(PushConfig.class);
+        verify(pushConfigMapper).updateById(captor.capture());
+        PushConfig saved = captor.getValue();
+        assertThat(saved.getMqttBroker()).isEqualTo("tcp://localhost:1883");
+        assertThat(saved.getMqttTopic()).isEqualTo("device/up");
+        assertThat(saved.getMqttUsername()).isEqualTo("user");
+        assertThat(saved.getMqttClientId()).isEqualTo("client-1");
+        assertThat(saved.getMqttQos()).isZero();
+        assertThat(saved.getMqttRetain()).isFalse();
+        assertThat(saved.getMqttKeepAlive()).isEqualTo(60);
+        assertThat(saved.getMqttCleanSession()).isTrue();
+        assertThat(saved.getHttpUrl()).isNull();
+        assertThat(saved.getHttpHeaders()).isEmpty();
+    }
+
+    private static PushConfig baseConfig(PushConfigType type) {
+        PushConfig config = new PushConfig();
+        config.setName("推送配置");
+        config.setType(type);
+        config.setIsEnabled(true);
+        return config;
+    }
+}

--- a/iot-web/src/views/push-config/widget/editDia.vue
+++ b/iot-web/src/views/push-config/widget/editDia.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { ElMessage } from 'element-plus'
 import { computed, ref, watch } from 'vue'
 import { pushConfigAddApi, pushConfigEditApi } from '@/api/index.js'
 import { useForm } from '@/composables/useForm.js'
@@ -23,10 +24,7 @@ const qosOpt = [
   { label: '2 - 恰好一次', value: 2 },
 ]
 
-const rules = ref({
-  name: [{ required: true, message: '配置名称不能为空', trigger: 'blur' }],
-  type: [{ required: true, message: '配置类型不能为空', trigger: 'change' }],
-})
+const blankToEmpty = value => `${value ?? ''}`.trim()
 
 const { form, onSubmit: handleSubmit, editRef, loading } = useForm({
   api: props.datas ? pushConfigEditApi : pushConfigAddApi,
@@ -39,22 +37,152 @@ const { form, onSubmit: handleSubmit, editRef, loading } = useForm({
 const isHttp = computed(() => form.value.type === 'HTTP')
 const isMqtt = computed(() => form.value.type === 'MQTT')
 
+function validateHttpUrl(_rule, value, callback) {
+  const url = blankToEmpty(value)
+  if (!isHttp.value) {
+    callback()
+    return
+  }
+  if (!url) {
+    callback(new Error('请求URL不能为空'))
+    return
+  }
+  if (!/^https?:\/\//i.test(url)) {
+    callback(new Error('请求URL必须以 http:// 或 https:// 开头'))
+    return
+  }
+  callback()
+}
+
+function validateMqttBroker(_rule, value, callback) {
+  const broker = blankToEmpty(value)
+  if (!isMqtt.value) {
+    callback()
+    return
+  }
+  if (!broker) {
+    callback(new Error('Broker地址不能为空'))
+    return
+  }
+  if (!/^(?:tcp|ssl|ws|wss):\/\//i.test(broker)) {
+    callback(new Error('Broker地址必须以 tcp://、ssl://、ws:// 或 wss:// 开头'))
+    return
+  }
+  callback()
+}
+
+function validateMqttTopic(_rule, value, callback) {
+  const topic = blankToEmpty(value)
+  if (!isMqtt.value) {
+    callback()
+    return
+  }
+  if (!topic) {
+    callback(new Error('目标Topic不能为空'))
+    return
+  }
+  if (topic.includes('#') || topic.includes('+')) {
+    callback(new Error('发布Topic不能包含通配符 # 或 +'))
+    return
+  }
+  callback()
+}
+
+const rules = ref({
+  name: [{ required: true, message: '配置名称不能为空', trigger: 'blur' }],
+  type: [{ required: true, message: '配置类型不能为空', trigger: 'change' }],
+  httpUrl: [{ validator: validateHttpUrl, trigger: 'blur' }],
+  httpMethod: [{ required: true, message: '请求方法不能为空', trigger: 'change' }],
+  mqttBroker: [{ validator: validateMqttBroker, trigger: 'blur' }],
+  mqttTopic: [{ validator: validateMqttTopic, trigger: 'blur' }],
+  mqttQos: [{ required: true, message: 'QoS等级不能为空', trigger: 'change' }],
+})
+
 // HTTP Headers 数组
 const httpHeaders = ref([])
 
 // MQTT Options 数组
 const mqttOptions = ref([])
 
-function onSubmit() {
-  // 转换数组为提交格式
-  const submitData = { ...form.value }
+function normalizeKeyValueList(list) {
+  const normalized = []
+  for (const item of list) {
+    const key = blankToEmpty(item.key)
+    const value = blankToEmpty(item.value)
+    if (!key && !value) {
+      continue
+    }
+    if (!key || !value) {
+      return null
+    }
+    normalized.push({ key, value })
+  }
+  return normalized
+}
+
+function normalizeFormBeforeSubmit() {
+  const submitData = {
+    ...form.value,
+    name: blankToEmpty(form.value.name),
+    description: blankToEmpty(form.value.description),
+  }
+
   if (isHttp.value) {
-    submitData.httpHeaders = httpHeaders.value.filter(h => h.key)
+    const headers = normalizeKeyValueList(httpHeaders.value)
+    if (!headers) {
+      ElMessage.warning('请求头的 Key 和 Value 需要同时填写')
+      return false
+    }
+    Object.assign(submitData, {
+      httpUrl: blankToEmpty(form.value.httpUrl),
+      httpMethod: form.value.httpMethod || 'POST',
+      httpHeaders: headers,
+      httpTimeout: form.value.httpTimeout || 5000,
+      mqttBroker: '',
+      mqttUsername: '',
+      mqttPassword: '',
+      mqttClientId: '',
+      mqttTopic: '',
+      mqttQos: 0,
+      mqttRetain: false,
+      mqttKeepAlive: 60,
+      mqttCleanSession: true,
+      mqttOptions: [],
+    })
   }
+
   if (isMqtt.value) {
-    submitData.mqttOptions = mqttOptions.value.filter(h => h.key)
+    const options = normalizeKeyValueList(mqttOptions.value)
+    if (!options) {
+      ElMessage.warning('MQTT扩展配置的 Key 和 Value 需要同时填写')
+      return false
+    }
+    Object.assign(submitData, {
+      mqttBroker: blankToEmpty(form.value.mqttBroker),
+      mqttUsername: blankToEmpty(form.value.mqttUsername),
+      mqttPassword: form.value.mqttPassword || '',
+      mqttClientId: blankToEmpty(form.value.mqttClientId),
+      mqttTopic: blankToEmpty(form.value.mqttTopic),
+      mqttQos: form.value.mqttQos ?? 0,
+      mqttRetain: !!form.value.mqttRetain,
+      mqttKeepAlive: form.value.mqttKeepAlive || 60,
+      mqttCleanSession: form.value.mqttCleanSession !== false,
+      mqttOptions: options,
+      httpUrl: '',
+      httpMethod: 'POST',
+      httpHeaders: [],
+      httpTimeout: 5000,
+    })
   }
+
   form.value = submitData
+  return true
+}
+
+function onSubmit() {
+  if (!normalizeFormBeforeSubmit()) {
+    return
+  }
   handleSubmit()
 }
 


### PR DESCRIPTION
## Summary
- add HTTP/MQTT specific validation and data cleanup in push config form
- normalize submitted push config values and prevent half-filled header/option rows
- add backend guardrails for HTTP callback URL, MQTT broker/topic, and stale cross-type fields
- cover service-level validation with regression tests

## Test Plan
- CI=true corepack pnpm lint
- CI=true corepack pnpm build
- JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw -pl iot-server -Dtest=PushConfigServiceTest test
- JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25/Contents/Home ./mvnw -pl iot-server -am test
- git diff --check