### PR TITLE
feat: ScriptFilterNode, rule-chain validation, debug path highlight, signed push testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ yarn.lock
 /iot-web/.env.development
 CLAUDE.md
 /.planning/
+/.hermes/
 
 # Codex / OMC local state
 .omc

--- a/doc/sql/init.sql
+++ b/doc/sql/init.sql
@@ -1129,6 +1129,8 @@ CREATE TABLE tb_push_config (
                                 http_method VARCHAR(10) DEFAULT 'POST',  -- GET / POST / PUT
                                 http_headers JSONB,                      -- 请求头 [{"key":"Content-Type","value":"application/json"}]
                                 http_timeout INTEGER DEFAULT 5000,       -- 超时时间(毫秒)
+                                http_sign_enabled BOOLEAN DEFAULT FALSE, -- 是否启用 HMAC 签名
+                                http_sign_secret VARCHAR(255),           -- HMAC 签名密钥
 
     -- ==================== MQTT 配置 ====================
                                 mqtt_broker VARCHAR(255),                -- Broker地址 (tcp://host:1883)
@@ -1162,6 +1164,8 @@ COMMENT ON COLUMN tb_push_config.http_url IS 'HTTP请求URL';
 COMMENT ON COLUMN tb_push_config.http_method IS 'HTTP请求方法: GET/POST/PUT';
 COMMENT ON COLUMN tb_push_config.http_headers IS 'HTTP请求头(JSON数组格式)';
 COMMENT ON COLUMN tb_push_config.http_timeout IS '超时时间(毫秒)';
+COMMENT ON COLUMN tb_push_config.http_sign_enabled IS '是否启用 HTTP HMAC 签名';
+COMMENT ON COLUMN tb_push_config.http_sign_secret IS 'HTTP HMAC 签名密钥';
 
 -- MQTT 配置注释
 COMMENT ON COLUMN tb_push_config.mqtt_broker IS 'MQTT Broker地址 (如: tcp://localhost:1883)';

--- a/iot-common/iot-protocol-core/src/main/java/com/github/dingdaoyi/proto/model/ProtocolException.java
+++ b/iot-common/iot-protocol-core/src/main/java/com/github/dingdaoyi/proto/model/ProtocolException.java
@@ -10,19 +10,22 @@ public class ProtocolException extends Exception {
     private final String deviceKey;
     private final ExceptionType type;
     private final Integer messageId;
+    private final String detailMessage;
 
     public ProtocolException(String deviceKey, ExceptionType type, Integer messageId) {
         super(type.msg);
         this.deviceKey = deviceKey;
         this.type = type;
         this.messageId = messageId;
+        this.detailMessage = null;
     }
 
-    public ProtocolException(String deviceKey, ExceptionType type, Integer messageId,String message) {
+    public ProtocolException(String deviceKey, ExceptionType type, Integer messageId, String message) {
         super(message);
         this.deviceKey = deviceKey;
         this.type = type;
         this.messageId = messageId;
+        this.detailMessage = message;
     }
     public ProtocolException(String deviceKey, ExceptionType type) {
         this(deviceKey, type, null);
@@ -30,6 +33,9 @@ public class ProtocolException extends Exception {
 
     @Override
     public String getMessage() {
+        if (detailMessage != null && !detailMessage.isBlank()) {
+            return detailMessage;
+        }
         if (messageId != null) {
             return type.msg + deviceKey + ":" + messageId;
         }

--- a/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/ProtocolController.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/ProtocolController.java
@@ -1,5 +1,7 @@
 package com.github.dingdaoyi.controller.iot;
 
+import com.github.dingdaoyi.controller.iot.dto.ProtocolDecodeTestRequest;
+import com.github.dingdaoyi.controller.iot.dto.ProtocolEncodeTestRequest;
 import com.github.dingdaoyi.entity.Protocol;
 import com.github.dingdaoyi.core.base.BaseResult;
 import com.github.dingdaoyi.service.ProductService;
@@ -58,5 +60,29 @@ public class ProtocolController {
     @Operation(summary = "设置协议状态")
     public BaseResult<Boolean> setStatus(@PathVariable Integer id, @RequestParam Boolean enable) {
         return BaseResult.success(protocolService.setProtocolStatus(id, enable));
+    }
+
+    @PostMapping("/test/decode")
+    @Operation(summary = "测试脚本协议解码")
+    public BaseResult<?> testDecode(@RequestBody ProtocolDecodeTestRequest request) throws Exception {
+        return BaseResult.success(protocolService.testDecode(
+                request.getProtocol(),
+                request.getDeviceKey(),
+                request.getProductKey(),
+                request.getMessageType(),
+                request.getData()
+        ));
+    }
+
+    @PostMapping("/test/encode")
+    @Operation(summary = "测试脚本协议编码")
+    public BaseResult<?> testEncode(@RequestBody ProtocolEncodeTestRequest request) throws Exception {
+        return BaseResult.success(protocolService.testEncode(
+                request.getProtocol(),
+                request.getDeviceKey(),
+                request.getProductKey(),
+                request.getIdentifier(),
+                request.getParams()
+        ));
     }
 }

--- a/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/PushConfigController.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/PushConfigController.java
@@ -1,5 +1,6 @@
 package com.github.dingdaoyi.controller.iot;
 
+import com.github.dingdaoyi.controller.iot.dto.PushTestRequest;
 import com.github.dingdaoyi.core.base.BaseResult;
 import com.github.dingdaoyi.core.base.PageResult;
 import com.github.dingdaoyi.core.enums.ResultCode;
@@ -10,6 +11,7 @@ import com.github.dingdaoyi.model.query.PushConfigUpdateQuery;
 import com.github.dingdaoyi.model.vo.PushConfigDetailVo;
 import com.github.dingdaoyi.model.vo.PushConfigPageVo;
 import com.github.dingdaoyi.service.PushConfigService;
+import com.github.dingdaoyi.service.push.PushDeliveryResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -55,6 +57,12 @@ public class PushConfigController {
     @Operation(summary = "删除配置")
     public BaseResult<Boolean> delete(@PathVariable Integer id) {
         return BaseResult.success(pushConfigService.removeById(id));
+    }
+
+    @PostMapping("{id}/test")
+    @Operation(summary = "测试推送配置")
+    public BaseResult<PushDeliveryResult> testPush(@PathVariable Integer id, @RequestBody PushTestRequest request) {
+        return BaseResult.success(pushConfigService.testPush(id, request));
     }
 
     @PostMapping("page")

--- a/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/RuleChainController.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/RuleChainController.java
@@ -12,6 +12,7 @@ import com.github.dingdaoyi.model.query.RuleChainPageQuery;
 import com.github.dingdaoyi.model.query.RuleChainUpdateQuery;
 import com.github.dingdaoyi.model.vo.RuleChainDebugResultVo;
 import com.github.dingdaoyi.model.vo.RuleChainDetailVo;
+import com.github.dingdaoyi.model.vo.RuleChainValidationResultVo;
 import com.github.dingdaoyi.model.vo.RuleChainPageVo;
 import com.github.dingdaoyi.proto.model.tsl.TslModel;
 import com.github.dingdaoyi.proto.model.tsl.TslProperty;
@@ -86,6 +87,12 @@ public class RuleChainController {
     @Operation(summary = "调试执行规则链草稿")
     public BaseResult<RuleChainDebugResultVo> debug(@RequestBody @Valid RuleChainDebugRequest request) {
         return BaseResult.success(ruleChainService.debug(request));
+    }
+
+    @PostMapping("validate")
+    @Operation(summary = "校验规则链草稿结构")
+    public BaseResult<RuleChainValidationResultVo> validate(@RequestBody RuleChain ruleChain) {
+        return BaseResult.success(ruleChainService.validateDraft(ruleChain));
     }
 
     @GetMapping("node-types")

--- a/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/RuleChainController.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/RuleChainController.java
@@ -1,5 +1,6 @@
 package com.github.dingdaoyi.controller.iot;
 
+import com.github.dingdaoyi.controller.iot.dto.RuleChainDebugRequest;
 import com.github.dingdaoyi.core.base.BaseResult;
 import com.github.dingdaoyi.core.base.PageResult;
 import com.github.dingdaoyi.core.enums.ResultCode;
@@ -9,6 +10,7 @@ import com.github.dingdaoyi.entity.enu.RuleNodeType;
 import com.github.dingdaoyi.model.query.RuleChainAddQuery;
 import com.github.dingdaoyi.model.query.RuleChainPageQuery;
 import com.github.dingdaoyi.model.query.RuleChainUpdateQuery;
+import com.github.dingdaoyi.model.vo.RuleChainDebugResultVo;
 import com.github.dingdaoyi.model.vo.RuleChainDetailVo;
 import com.github.dingdaoyi.model.vo.RuleChainPageVo;
 import com.github.dingdaoyi.proto.model.tsl.TslModel;
@@ -78,6 +80,12 @@ public class RuleChainController {
         ruleChain.setId(id);
         ruleChain.setIsEnabled(enabled);
         return BaseResult.success(ruleChainService.updateById(ruleChain));
+    }
+
+    @PostMapping("debug")
+    @Operation(summary = "调试执行规则链草稿")
+    public BaseResult<RuleChainDebugResultVo> debug(@RequestBody @Valid RuleChainDebugRequest request) {
+        return BaseResult.success(ruleChainService.debug(request));
     }
 
     @GetMapping("node-types")

--- a/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/dto/ProtocolDecodeTestRequest.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/dto/ProtocolDecodeTestRequest.java
@@ -1,0 +1,26 @@
+package com.github.dingdaoyi.controller.iot.dto;
+
+import com.github.dingdaoyi.entity.Protocol;
+import com.github.dingdaoyi.proto.model.ProtoMessageType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Schema(description = "协议脚本解码测试请求")
+@Data
+public class ProtocolDecodeTestRequest {
+
+    @Schema(description = "待测试协议草稿")
+    private Protocol protocol;
+
+    @Schema(description = "设备Key")
+    private String deviceKey;
+
+    @Schema(description = "产品Key")
+    private String productKey;
+
+    @Schema(description = "消息类型")
+    private ProtoMessageType messageType = ProtoMessageType.PROPERTY;
+
+    @Schema(description = "原始报文，按 UTF-8 字符串传入")
+    private String data;
+}

--- a/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/dto/ProtocolEncodeTestRequest.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/dto/ProtocolEncodeTestRequest.java
@@ -1,0 +1,28 @@
+package com.github.dingdaoyi.controller.iot.dto;
+
+import com.github.dingdaoyi.entity.Protocol;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Schema(description = "协议脚本编码测试请求")
+@Data
+public class ProtocolEncodeTestRequest {
+
+    @Schema(description = "待测试协议草稿")
+    private Protocol protocol;
+
+    @Schema(description = "设备Key")
+    private String deviceKey;
+
+    @Schema(description = "产品Key")
+    private String productKey;
+
+    @Schema(description = "功能/属性标识符")
+    private String identifier;
+
+    @Schema(description = "下行参数")
+    private Map<String, Object> params = new HashMap<>();
+}

--- a/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/dto/PushTestRequest.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/dto/PushTestRequest.java
@@ -1,0 +1,18 @@
+package com.github.dingdaoyi.controller.iot.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+/**
+ * 推送配置测试请求。
+ */
+@Data
+@Schema(description = "推送配置测试请求")
+public class PushTestRequest {
+
+    @Schema(description = "事件类型，会写入 X-Simple-IoT-Event 请求头")
+    private String eventType = "push.test";
+
+    @Schema(description = "测试推送负载。可以是 JSON 字符串、普通字符串或对象")
+    private Object payload;
+}

--- a/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/dto/RuleChainDebugRequest.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/controller/iot/dto/RuleChainDebugRequest.java
@@ -1,0 +1,50 @@
+package com.github.dingdaoyi.controller.iot.dto;
+
+import com.github.dingdaoyi.entity.RuleChain;
+import com.github.dingdaoyi.rule.RuleContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.Map;
+
+/**
+ * 规则链草稿调试请求。
+ *
+ * @author dingyunwei
+ */
+@Data
+@Schema(description = "规则链草稿调试请求")
+public class RuleChainDebugRequest {
+
+    @Valid
+    @NotNull(message = "规则链不能为空")
+    @Schema(description = "待调试的规则链草稿，支持未保存配置")
+    private RuleChain ruleChain;
+
+    @Schema(description = "设备Key")
+    private String deviceKey;
+
+    @Schema(description = "设备ID")
+    private Integer deviceId;
+
+    @Schema(description = "设备名称")
+    private String deviceName;
+
+    @NotNull(message = "消息类型不能为空")
+    @Schema(description = "消息类型: PROPERTY/EVENT/SERVICE_RES/ONLINE/OFFLINE")
+    private RuleContext.MessageType messageType;
+
+    @Schema(description = "属性上报模拟数据，key为属性标识符，value为属性值")
+    private Map<String, Object> properties;
+
+    @Schema(description = "事件标识符")
+    private String eventIdentifier;
+
+    @Schema(description = "事件参数模拟数据，key为参数标识符，value为参数值")
+    private Map<String, Object> eventParams;
+
+    @Schema(description = "额外上下文变量，可用于模板和脚本调试")
+    private Map<String, Object> enrichedData;
+}

--- a/iot-server/src/main/java/com/github/dingdaoyi/entity/PushConfig.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/entity/PushConfig.java
@@ -61,6 +61,14 @@ public class PushConfig extends BaseEntity {
     @Schema(description = "超时时间(毫秒)")
     private Integer httpTimeout;
 
+    @TableField(value = "http_sign_enabled")
+    @Schema(description = "是否启用 HTTP HMAC 签名")
+    private Boolean httpSignEnabled;
+
+    @TableField(value = "http_sign_secret")
+    @Schema(description = "HTTP HMAC 签名密钥")
+    private String httpSignSecret;
+
     // ==================== MQTT 配置 ====================
 
     @TableField(value = "mqtt_broker")

--- a/iot-server/src/main/java/com/github/dingdaoyi/iot/proto/script/ScriptProtocolDecoder.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/iot/proto/script/ScriptProtocolDecoder.java
@@ -1,13 +1,28 @@
 package com.github.dingdaoyi.iot.proto.script;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dingdaoyi.iot.proto.impl.ScriptProtocolInitialize.ScriptType;
 import com.github.dingdaoyi.proto.inter.DeviceConnection;
-import com.github.dingdaoyi.proto.model.*;
 import com.github.dingdaoyi.proto.inter.ProtocolDecoder;
+import com.github.dingdaoyi.proto.model.DataTypeEnum;
+import com.github.dingdaoyi.proto.model.DecodeResult;
+import com.github.dingdaoyi.proto.model.DeviceData;
+import com.github.dingdaoyi.proto.model.DeviceEventData;
+import com.github.dingdaoyi.proto.model.DeviceRequest;
+import com.github.dingdaoyi.proto.model.DeviceServiceResData;
+import com.github.dingdaoyi.proto.model.EncoderMessage;
+import com.github.dingdaoyi.proto.model.EncoderResult;
+import com.github.dingdaoyi.proto.model.ExceptionType;
+import com.github.dingdaoyi.proto.model.ProtocolException;
+import com.github.dingdaoyi.proto.model.tsl.EventTypeEnum;
 import com.github.dingdaoyi.proto.model.tsl.TslModel;
 import lombok.extern.slf4j.Slf4j;
-import org.graalvm.polyglot.*;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.PolyglotException;
+import org.graalvm.polyglot.Value;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,6 +39,8 @@ import java.util.Map;
  */
 @Slf4j
 public class ScriptProtocolDecoder implements ProtocolDecoder {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final String protocolKey;
     private final String protocolName;
@@ -66,22 +83,26 @@ public class ScriptProtocolDecoder implements ProtocolDecoder {
      */
     private void initJavaScriptEngine() {
         try {
-            // 创建 GraalVM Context
+            // 不开放 HostAccess，脚本协议只通过 JSON 结构与平台交互，降低脚本误访问宿主环境的风险。
             context = Context.newBuilder("js")
-                    .allowAllAccess(true)
+                    .allowAllAccess(false)
+                    .option("engine.WarnInterpreterOnly", "false")
                     .build();
 
-            // 创建 exports 对象
-            Value exports = context.eval("js", "({ decode: null, encode: null })");
+            // 支持 exports.decode/exports.encode 以及 module.exports = { decode, encode } 两种常见写法。
+            String wrappedScript = """
+                    (function() {
+                      const exports = {};
+                      const module = { exports };
+                    """ + scriptContent + """
 
-            // 执行脚本，将函数定义到 exports 对象中
-            // 包装脚本：用 (function(exports) { ... })(exports) 形式
-            String wrappedScript = "(function(exports) {\n" + scriptContent + "\n return exports;\n})(" + exports + ")";
+                      return module.exports || exports;
+                    })()
+                    """;
 
             Value result = context.eval("js", wrappedScript);
 
-            // 从返回的 exports 对象中获取函数
-            if (result.hasMembers()) {
+            if (result != null && result.hasMembers()) {
                 Value decodeFn = result.getMember("decode");
                 Value encodeFn = result.getMember("encode");
 
@@ -111,18 +132,8 @@ public class ScriptProtocolDecoder implements ProtocolDecoder {
      * 初始化 Groovy 引擎
      */
     private void initGroovyEngine() {
-        try {
-            context = Context.newBuilder("js")
-                    .allowAllAccess(true)
-                    .build();
-
-            // Groovy 需要使用 JSR-223 API，这里先用 JavaScript 兼容模式
-            log.warn("Groovy 引擎暂未完全实现，使用 JavaScript 兼容模式: {}", protocolKey);
-            initJavaScriptEngine();
-
-        } catch (Exception e) {
-            log.error("Groovy 引擎初始化失败: {}", protocolKey, e);
-        }
+        log.warn("Groovy 引擎暂未完全实现，使用 JavaScript 兼容模式: {}", protocolKey);
+        initJavaScriptEngine();
     }
 
     @Override
@@ -133,40 +144,44 @@ public class ScriptProtocolDecoder implements ProtocolDecoder {
     @Override
     public DecodeResult decode(DeviceRequest request, TslModel tslModel) throws ProtocolException {
         if (context == null) {
-            throw new ProtocolException(request.getDeviceKey(), ExceptionType.SYSTEM_ERROR,-1,
-                "脚本引擎未初始化: " + scriptType.getDisplayName());
+            throw new ProtocolException(request.getDeviceKey(), ExceptionType.SYSTEM_ERROR, -1,
+                    "脚本引擎未初始化: " + scriptType.getDisplayName());
+        }
+        if (decodeFunction == null || !decodeFunction.canExecute()) {
+            throw new ProtocolException(request.getDeviceKey(), ExceptionType.SYSTEM_ERROR, -1,
+                    "脚本协议未定义 decode(request, tslModel) 函数: " + protocolKey);
         }
 
         try {
-            // 构建输入参数
             Map<String, Object> inputData = new HashMap<>();
             inputData.put("deviceKey", request.getDeviceKey());
-            inputData.put("messageType", request.getMessageType().name());
-            inputData.put("data", request.getData() != null ? new String(request.getData()) : "");
+            inputData.put("productKey", request.getProductKey());
+            inputData.put("protoKey", request.getProtoKey());
+            inputData.put("messageType", request.getMessageType() == null ? null : request.getMessageType().name());
+            inputData.put("data", request.getData() != null ? new String(request.getData(), StandardCharsets.UTF_8) : "");
 
-            // 调用 decode 函数
-            Value result;
-            if (decodeFunction != null && decodeFunction.canExecute()) {
-                result = decodeFunction.execute(
-                        toValue(context, inputData),
-                        toValue(context, tslModel)
-                );
-            } else {
-                // 直接执行脚本
-                result = context.eval("js", scriptContent);
-            }
+            Value result = decodeFunction.execute(
+                    toJavaScriptValue(inputData),
+                    toJavaScriptValue(tslModel)
+            );
 
             if (result == null || result.isNull()) {
                 throw new ProtocolException(request.getDeviceKey(), ExceptionType.INVALID_PARAM, -1,
-                    "脚本未返回解析结果");
+                        "脚本未返回解析结果");
             }
 
             return parseScriptResult(result, request);
 
+        } catch (ProtocolException e) {
+            throw e;
         } catch (PolyglotException e) {
             log.error("脚本执行失败: {}, 错误: {}", protocolKey, e.getMessage(), e);
             throw new ProtocolException(request.getDeviceKey(), ExceptionType.SYSTEM_ERROR, -1,
-                "脚本执行失败: " + e.getMessage());
+                    "脚本执行失败: " + e.getMessage());
+        } catch (Exception e) {
+            log.error("脚本执行上下文构建失败: {}", protocolKey, e);
+            throw new ProtocolException(request.getDeviceKey(), ExceptionType.SYSTEM_ERROR, -1,
+                    "脚本执行上下文构建失败: " + e.getMessage());
         }
     }
 
@@ -177,90 +192,114 @@ public class ScriptProtocolDecoder implements ProtocolDecoder {
         DecodeResult decodeResult = new DecodeResult();
 
         try {
-            // 检查结果是否是对象
-            if (result.hasMembers()) {
-                // 提取 messageId
-                Value messageIdValue = result.getMember("messageId");
-                if (!messageIdValue.isNull()) {
-                    decodeResult.setMessageId(messageIdValue.asInt());
-                }
+            if (!result.hasMembers()) {
+                throw new IllegalArgumentException("decode 返回值必须是对象");
+            }
 
-                // 提取 rawData
-                Value rawDataValue = result.getMember("rawData");
-                if (!rawDataValue.isNull()) {
-                    decodeResult.setRowData(rawDataValue.asString());
-                }
+            Value messageIdValue = result.getMember("messageId");
+            if (hasValue(messageIdValue)) {
+                decodeResult.setMessageId(toInteger(messageIdValue));
+            }
 
-                // 提取 dataList
-                Value dataListValue = result.getMember("dataList");
-                if (!dataListValue.isNull() && dataListValue.hasArrayElements()) {
-                    long length = dataListValue.getArraySize();
-                    for (long i = 0; i < length; i++) {
-                        Value item = dataListValue.getArrayElement(i);
-                        if (item.hasMembers()) {
-                            String identifier = item.getMember("identifier").asString();
-                            Value valueValue = item.getMember("value");
-                            Object value = convertValue(valueValue);
+            Value rawDataValue = firstMember(result, "rawData", "rowData");
+            if (hasValue(rawDataValue)) {
+                decodeResult.setRowData(String.valueOf(convertValue(rawDataValue)));
+            }
 
-                            String typeStr = "STRING";
-                            Value typeValue = item.getMember("type");
-                            if (!typeValue.isNull()) {
-                                typeStr = typeValue.asString();
-                            }
-
-                            DataTypeEnum dataType = parseDataType(typeStr);
-                            decodeResult.getDataList().add(new DeviceData(identifier, dataType, value));
-                        }
+            Value dataListValue = result.getMember("dataList");
+            if (hasValue(dataListValue) && dataListValue.hasArrayElements()) {
+                long length = dataListValue.getArraySize();
+                for (long i = 0; i < length; i++) {
+                    Value item = dataListValue.getArrayElement(i);
+                    if (item != null && item.hasMembers()) {
+                        decodeResult.getDataList().add(parseDeviceData(item));
                     }
                 }
+            }
 
-                // 提取 eventData (如果有)
-                Value eventDataValue = result.getMember("eventData");
-                if (!eventDataValue.isNull()) {
-                    // 处理事件数据
-                    log.debug("检测到事件数据");
-                }
+            Value eventDataValue = result.getMember("eventData");
+            if (hasValue(eventDataValue) && eventDataValue.hasMembers()) {
+                decodeResult.setEventData(parseEventData(eventDataValue));
+            }
 
-                // 提取 serviceResData (如果有)
-                Value serviceResValue = result.getMember("serviceResData");
-                if (!serviceResValue.isNull()) {
-                    // 处理服务响应数据
-                    log.debug("检测到服务响应数据");
-                }
+            Value serviceResValue = result.getMember("serviceResData");
+            if (hasValue(serviceResValue) && serviceResValue.hasMembers()) {
+                decodeResult.setServiceResData(parseServiceResData(serviceResValue));
             }
 
         } catch (Exception e) {
             log.error("解析脚本结果失败: {}", protocolKey, e);
             throw new ProtocolException(request.getDeviceKey(), ExceptionType.INVALID_PARAM, -1,
-                "解析脚本结果失败: " + e.getMessage());
+                    "解析脚本结果失败: " + e.getMessage());
         }
 
         return decodeResult;
+    }
+
+    private DeviceData parseDeviceData(Value item) {
+        String identifier = asString(firstMember(item, "identifier", "id", "code"));
+        Value valueValue = item.getMember("value");
+        Object value = hasValue(valueValue) ? convertValue(valueValue) : null;
+        String typeStr = asString(firstMember(item, "type", "dataType"));
+        return new DeviceData(identifier, parseDataType(typeStr), value);
+    }
+
+    private DeviceEventData parseEventData(Value eventDataValue) {
+        String identifier = asString(firstMember(eventDataValue, "eventIdentifier", "identifier", "id", "code"));
+        EventTypeEnum eventType = parseEventType(firstMember(eventDataValue, "eventType", "type", "level"));
+        DeviceEventData eventData = new DeviceEventData(identifier, eventType);
+
+        Value paramsValue = firstMember(eventDataValue, "params", "dataList");
+        if (hasValue(paramsValue) && paramsValue.hasArrayElements()) {
+            long length = paramsValue.getArraySize();
+            for (long i = 0; i < length; i++) {
+                Value item = paramsValue.getArrayElement(i);
+                if (item != null && item.hasMembers()) {
+                    eventData.getParams().add(parseDeviceData(item));
+                }
+            }
+        }
+        return eventData;
+    }
+
+    private DeviceServiceResData parseServiceResData(Value serviceResValue) {
+        String identifier = asString(firstMember(serviceResValue, "serviceIdentifier", "identifier", "id", "code"));
+        DeviceServiceResData serviceResData = new DeviceServiceResData(identifier);
+
+        Value resultDataValue = firstMember(serviceResValue, "resultData", "results", "params", "dataList");
+        if (hasValue(resultDataValue) && resultDataValue.hasArrayElements()) {
+            long length = resultDataValue.getArraySize();
+            for (long i = 0; i < length; i++) {
+                Value item = resultDataValue.getArrayElement(i);
+                if (item != null && item.hasMembers()) {
+                    serviceResData.getResultData().add(parseDeviceData(item));
+                }
+            }
+        }
+        return serviceResData;
     }
 
     /**
      * 转换 Value 为 Java 对象
      */
     private Object convertValue(Value value) {
-        if (value.isNull()) {
+        if (!hasValue(value)) {
             return null;
         }
         if (value.isBoolean()) {
             return value.asBoolean();
         }
         if (value.isNumber()) {
-            // 尝试返回合适的数值类型
-            long longValue = value.asLong();
-            if (longValue == value.asDouble()) {
-                return longValue;
+            double doubleValue = value.asDouble();
+            if (Math.rint(doubleValue) == doubleValue && value.fitsInLong()) {
+                return value.asLong();
             }
-            return value.asDouble();
+            return doubleValue;
         }
         if (value.isString()) {
             return value.asString();
         }
         if (value.hasArrayElements()) {
-            // 处理数组
             long size = value.getArraySize();
             Object[] array = new Object[(int) size];
             for (int i = 0; i < size; i++) {
@@ -269,49 +308,77 @@ public class ScriptProtocolDecoder implements ProtocolDecoder {
             return array;
         }
         if (value.hasMembers()) {
-            // 处理对象
             Map<String, Object> map = new HashMap<>();
             for (String key : value.getMemberKeys()) {
                 map.put(key, convertValue(value.getMember(key)));
             }
             return map;
         }
-        return value.asString();
+        return value.toString();
     }
 
-    /**
-     * 将 Java 对象转换为 Value
-     */
-    private Value toValue(Context context, Object obj) {
-        if (obj == null) {
-            return context.asValue(null);
+    private Value toJavaScriptValue(Object value) throws JsonProcessingException {
+        if (value == null) {
+            return context.eval("js", "null");
         }
-        if (obj instanceof Value) {
-            return (Value) obj;
+        return context.eval("js", "JSON.parse(" + OBJECT_MAPPER.writeValueAsString(OBJECT_MAPPER.writeValueAsString(value)) + ")");
+    }
+
+    private boolean hasValue(Value value) {
+        return value != null && !value.isNull();
+    }
+
+    private Value firstMember(Value value, String... names) {
+        if (value == null || !value.hasMembers()) {
+            return null;
         }
-        if (obj instanceof String || obj instanceof Number || obj instanceof Boolean) {
-            return context.asValue(obj);
-        }
-        if (obj instanceof Map) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> map = (Map<String, Object>) obj;
-            Map<String, Object> result = new HashMap<>();
-            for (Map.Entry<String, Object> entry : map.entrySet()) {
-                result.put(entry.getKey(), convertToJava(entry.getValue()));
+        for (String name : names) {
+            Value member = value.getMember(name);
+            if (hasValue(member)) {
+                return member;
             }
-            return context.asValue(result);
         }
-        return context.asValue(obj);
+        return null;
     }
 
-    /**
-     * 转换为纯 Java 对象
-     */
-    private Object convertToJava(Object obj) {
-        if (obj == null || obj instanceof String || obj instanceof Number || obj instanceof Boolean) {
-            return obj;
+    private String asString(Value value) {
+        if (!hasValue(value)) {
+            return null;
         }
-        return obj;
+        Object converted = convertValue(value);
+        return converted == null ? null : String.valueOf(converted);
+    }
+
+    private Integer toInteger(Value value) {
+        if (!hasValue(value)) {
+            return null;
+        }
+        if (value.isNumber()) {
+            return value.asInt();
+        }
+        return Integer.parseInt(value.asString());
+    }
+
+    private EventTypeEnum parseEventType(Value eventTypeValue) {
+        if (!hasValue(eventTypeValue)) {
+            return EventTypeEnum.INFO;
+        }
+        if (eventTypeValue.isNumber()) {
+            return EventTypeEnum.of(eventTypeValue.asInt());
+        }
+        String value = eventTypeValue.asString();
+        if (value == null || value.isBlank()) {
+            return EventTypeEnum.INFO;
+        }
+        try {
+            return EventTypeEnum.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            try {
+                return EventTypeEnum.of(Integer.parseInt(value));
+            } catch (NumberFormatException ignored) {
+                return EventTypeEnum.INFO;
+            }
+        }
     }
 
     /**
@@ -338,62 +405,83 @@ public class ScriptProtocolDecoder implements ProtocolDecoder {
     public EncoderResult encode(EncoderMessage message, TslModel tslModel) throws ProtocolException {
         if (context == null) {
             throw new ProtocolException("encode", ExceptionType.SYSTEM_ERROR, -1,
-                "脚本引擎未初始化: " + scriptType.getDisplayName());
+                    "脚本引擎未初始化: " + scriptType.getDisplayName());
+        }
+        if (encodeFunction == null || !encodeFunction.canExecute()) {
+            throw new ProtocolException("encode", ExceptionType.SYSTEM_ERROR, -1,
+                    "脚本协议未定义 encode(message, tslModel) 函数: " + protocolKey);
         }
 
         try {
-            // 构建输入参数
             Map<String, Object> inputData = new HashMap<>();
             inputData.put("identifier", message.getIdentifier());
+            inputData.put("deviceKey", message.getDeviceKey());
+            inputData.put("productKey", message.getProductKey());
             inputData.put("params", message.getParams());
 
-            // 调用 encode 函数
-            Value result;
-            if (encodeFunction != null && encodeFunction.canExecute()) {
-                result = encodeFunction.execute(
-                        toValue(context, inputData),
-                        toValue(context, tslModel)
-                );
-            } else {
-                // 直接执行脚本（需要脚本支持 encode 函数）
-                result = context.eval("js", scriptContent);
-            }
+            Value result = encodeFunction.execute(
+                    toJavaScriptValue(inputData),
+                    toJavaScriptValue(tslModel)
+            );
 
-            EncoderResult encoderResult = new EncoderResult();
+            return parseEncodeResult(result);
 
-            if (result != null && !result.isNull() && result.hasMembers()) {
-                // 提取 messageId
-                Value messageIdValue = result.getMember("messageId");
-                if (!messageIdValue.isNull()) {
-                    encoderResult.setMessageId(messageIdValue.asInt());
-                }
-
-                // 提取 message
-                Value messageValue = result.getMember("message");
-                if (!messageValue.isNull()) {
-                    if (messageValue.isString()) {
-                        encoderResult.setMessage(messageValue.asString().getBytes());
-                    }
-                }
-
-                // 提取 metadata
-                Value metadataValue = result.getMember("metadata");
-                if (!metadataValue.isNull() && metadataValue.hasMembers()) {
-                    Map<String, Object> metadata = new HashMap<>();
-                    for (String key : metadataValue.getMemberKeys()) {
-                        metadata.put(key, convertValue(metadataValue.getMember(key)));
-                    }
-                    encoderResult.setMetadata(metadata);
-                }
-            }
-
-            return encoderResult;
-
+        } catch (ProtocolException e) {
+            throw e;
         } catch (PolyglotException e) {
             log.error("脚本编码失败: {}, 错误: {}", protocolKey, e.getMessage(), e);
             throw new ProtocolException("encode", ExceptionType.SYSTEM_ERROR, -1,
-                "脚本编码失败: " + e.getMessage());
+                    "脚本编码失败: " + e.getMessage());
+        } catch (Exception e) {
+            log.error("脚本编码结果解析失败: {}", protocolKey, e);
+            throw new ProtocolException("encode", ExceptionType.INVALID_PARAM, -1,
+                    "脚本编码结果解析失败: " + e.getMessage());
         }
+    }
+
+    private EncoderResult parseEncodeResult(Value result) throws ProtocolException {
+        if (result == null || result.isNull() || !result.hasMembers()) {
+            throw new ProtocolException("encode", ExceptionType.INVALID_PARAM, -1, "encode 返回值必须是对象");
+        }
+
+        EncoderResult encoderResult = new EncoderResult();
+
+        Value messageIdValue = result.getMember("messageId");
+        if (hasValue(messageIdValue)) {
+            encoderResult.setMessageId(toInteger(messageIdValue));
+        }
+
+        Value needReplyValue = result.getMember("needReply");
+        if (hasValue(needReplyValue)) {
+            encoderResult.setNeedReply(needReplyValue.asBoolean());
+        }
+
+        Value messageValue = result.getMember("message");
+        if (hasValue(messageValue)) {
+            Object message = convertValue(messageValue);
+            if (message instanceof byte[] bytes) {
+                encoderResult.setMessage(bytes);
+            } else if (message instanceof Object[] array) {
+                byte[] bytes = new byte[array.length];
+                for (int i = 0; i < array.length; i++) {
+                    bytes[i] = ((Number) array[i]).byteValue();
+                }
+                encoderResult.setMessage(bytes);
+            } else {
+                encoderResult.setMessage(String.valueOf(message).getBytes(StandardCharsets.UTF_8));
+            }
+        }
+
+        Value metadataValue = result.getMember("metadata");
+        if (hasValue(metadataValue) && metadataValue.hasMembers()) {
+            Map<String, Object> metadata = new HashMap<>();
+            for (String key : metadataValue.getMemberKeys()) {
+                metadata.put(key, convertValue(metadataValue.getMember(key)));
+            }
+            encoderResult.setMetadata(metadata);
+        }
+
+        return encoderResult;
     }
 
     @Override

--- a/iot-server/src/main/java/com/github/dingdaoyi/model/query/PushConfigAddQuery.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/model/query/PushConfigAddQuery.java
@@ -46,6 +46,12 @@ public class PushConfigAddQuery implements ToEntity<PushConfig> {
     @Schema(description = "超时时间(毫秒)")
     private Integer httpTimeout = 5000;
 
+    @Schema(description = "是否启用 HTTP HMAC 签名")
+    private Boolean httpSignEnabled = false;
+
+    @Schema(description = "HTTP HMAC 签名密钥")
+    private String httpSignSecret;
+
     // ==================== MQTT 配置 ====================
 
     @Schema(description = "MQTT Broker地址")
@@ -91,6 +97,8 @@ public class PushConfigAddQuery implements ToEntity<PushConfig> {
         config.setHttpMethod(httpMethod);
         config.setHttpHeaders(httpHeaders);
         config.setHttpTimeout(httpTimeout);
+        config.setHttpSignEnabled(httpSignEnabled);
+        config.setHttpSignSecret(httpSignSecret);
 
         // MQTT 配置
         config.setMqttBroker(mqttBroker);

--- a/iot-server/src/main/java/com/github/dingdaoyi/model/query/PushConfigUpdateQuery.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/model/query/PushConfigUpdateQuery.java
@@ -50,6 +50,12 @@ public class PushConfigUpdateQuery implements ToEntity<PushConfig> {
     @Schema(description = "超时时间(毫秒)")
     private Integer httpTimeout = 5000;
 
+    @Schema(description = "是否启用 HTTP HMAC 签名")
+    private Boolean httpSignEnabled = false;
+
+    @Schema(description = "HTTP HMAC 签名密钥")
+    private String httpSignSecret;
+
     // ==================== MQTT 配置 ====================
 
     @Schema(description = "MQTT Broker地址")
@@ -96,6 +102,8 @@ public class PushConfigUpdateQuery implements ToEntity<PushConfig> {
         config.setHttpMethod(httpMethod);
         config.setHttpHeaders(httpHeaders);
         config.setHttpTimeout(httpTimeout);
+        config.setHttpSignEnabled(httpSignEnabled);
+        config.setHttpSignSecret(httpSignSecret);
 
         // MQTT 配置
         config.setMqttBroker(mqttBroker);

--- a/iot-server/src/main/java/com/github/dingdaoyi/model/vo/PushConfigDetailVo.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/model/vo/PushConfigDetailVo.java
@@ -44,6 +44,12 @@ public class PushConfigDetailVo {
     @Schema(description = "超时时间(毫秒)")
     private Integer httpTimeout;
 
+    @Schema(description = "是否启用 HTTP HMAC 签名")
+    private Boolean httpSignEnabled;
+
+    @Schema(description = "HTTP HMAC 签名密钥")
+    private String httpSignSecret;
+
     // ==================== MQTT 配置 ====================
 
     @Schema(description = "MQTT Broker地址")

--- a/iot-server/src/main/java/com/github/dingdaoyi/model/vo/RuleChainDebugResultVo.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/model/vo/RuleChainDebugResultVo.java
@@ -1,0 +1,35 @@
+package com.github.dingdaoyi.model.vo;
+
+import com.github.dingdaoyi.rule.RuleContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 规则链调试结果。
+ *
+ * @author dingyunwei
+ */
+@Data
+@Schema(description = "规则链调试结果")
+public class RuleChainDebugResultVo {
+
+    @Schema(description = "规则链ID，草稿调试时可能为空")
+    private Integer ruleChainId;
+
+    @Schema(description = "规则链名称")
+    private String ruleChainName;
+
+    @Schema(description = "是否整体执行成功，任一节点失败则为 false")
+    private boolean success;
+
+    @Schema(description = "总耗时，毫秒")
+    private long durationMs;
+
+    @Schema(description = "执行节点数量")
+    private int executedNodeCount;
+
+    @Schema(description = "执行轨迹")
+    private List<RuleContext.ExecutionTrace> traces;
+}

--- a/iot-server/src/main/java/com/github/dingdaoyi/model/vo/RuleChainDebugResultVo.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/model/vo/RuleChainDebugResultVo.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 规则链调试结果。
@@ -32,4 +33,10 @@ public class RuleChainDebugResultVo {
 
     @Schema(description = "执行轨迹")
     private List<RuleContext.ExecutionTrace> traces;
+
+    @Schema(description = "调试执行经过的连接路径")
+    private List<Map<String, String>> executedConnections;
+
+    @Schema(description = "规则链结构校验结果")
+    private RuleChainValidationResultVo validation;
 }

--- a/iot-server/src/main/java/com/github/dingdaoyi/model/vo/RuleChainValidationResultVo.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/model/vo/RuleChainValidationResultVo.java
@@ -1,0 +1,58 @@
+package com.github.dingdaoyi.model.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 规则链草稿校验结果。
+ *
+ * @author dingyunwei
+ */
+@Data
+@Schema(description = "规则链草稿校验结果")
+public class RuleChainValidationResultVo {
+
+    @Schema(description = "是否校验通过")
+    private boolean valid = true;
+
+    @Schema(description = "错误列表，存在错误时不建议保存/运行")
+    private List<Issue> errors = new ArrayList<>();
+
+    @Schema(description = "告警列表，可保存但需要用户确认")
+    private List<Issue> warnings = new ArrayList<>();
+
+    @Schema(description = "从输入节点可达的节点ID列表")
+    private List<String> reachableNodeIds = new ArrayList<>();
+
+    public void addError(String code, String nodeId, String connectionId, String message) {
+        errors.add(new Issue(code, nodeId, connectionId, message));
+        valid = false;
+    }
+
+    public void addWarning(String code, String nodeId, String connectionId, String message) {
+        warnings.add(new Issue(code, nodeId, connectionId, message));
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "规则链校验问题")
+    public static class Issue {
+        @Schema(description = "问题编码")
+        private String code;
+
+        @Schema(description = "关联节点ID")
+        private String nodeId;
+
+        @Schema(description = "关联连接ID")
+        private String connectionId;
+
+        @Schema(description = "问题描述")
+        private String message;
+    }
+}

--- a/iot-server/src/main/java/com/github/dingdaoyi/rule/RuleChainEngine.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/rule/RuleChainEngine.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import jakarta.annotation.Resource;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -67,14 +68,39 @@ public class RuleChainEngine {
 
         if (executor == null) {
             log.warn("未找到节点执行器: {}", nodeType);
+            context.addTrace(RuleContext.ExecutionTrace.builder()
+                .nodeId(node.getId())
+                .nodeName(node.getName())
+                .nodeType(nodeType.name())
+                .connectionType("Failure")
+                .status("SKIPPED")
+                .detail("未找到节点执行器: " + nodeType)
+                .timestamp(LocalDateTime.now())
+                .input(snapshotContext(context))
+                .output(Map.of("connectionType", "Failure"))
+                .build());
             return;
         }
 
+        long start = System.nanoTime();
+        Map<String, Object> inputSnapshot = snapshotContext(context);
         try {
             RuleNodeExecutor.NodeResult result = executor.execute(context, node.getConfig());
+            long durationMs = (System.nanoTime() - start) / 1_000_000;
             String connectionType = result.connectionType();
             String message = result.message();
-            context.addTrace(node.getId(), node.getName(), connectionType, message);
+            context.addTrace(RuleContext.ExecutionTrace.builder()
+                .nodeId(node.getId())
+                .nodeName(node.getName())
+                .nodeType(nodeType.name())
+                .connectionType(connectionType)
+                .status(result.success() ? "SUCCESS" : "FAILED")
+                .detail(message)
+                .durationMs(durationMs)
+                .timestamp(LocalDateTime.now())
+                .input(inputSnapshot)
+                .output(snapshotResult(result))
+                .build());
 
             List<Connection> connections = connectionMap.getOrDefault(node.getId(), Collections.emptyList());
             connections.stream()
@@ -87,9 +113,59 @@ public class RuleChainEngine {
                 });
 
         } catch (Exception e) {
+            long durationMs = (System.nanoTime() - start) / 1_000_000;
             log.error("节点执行失败: {} - {}", node.getName(), e.getMessage(), e);
-            context.addTrace(node.getId(), node.getName(), "Failure", e.getMessage());
+            context.addTrace(RuleContext.ExecutionTrace.builder()
+                .nodeId(node.getId())
+                .nodeName(node.getName())
+                .nodeType(nodeType.name())
+                .connectionType("Failure")
+                .status("ERROR")
+                .detail(e.getMessage())
+                .error(e.getMessage())
+                .durationMs(durationMs)
+                .timestamp(LocalDateTime.now())
+                .input(inputSnapshot)
+                .output(Map.of("connectionType", "Failure"))
+                .build());
         }
+    }
+
+    private Map<String, Object> snapshotContext(RuleContext context) {
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        snapshot.put("deviceKey", context.getDeviceKey());
+        snapshot.put("deviceId", context.getDeviceId());
+        snapshot.put("deviceName", context.getDeviceName());
+        snapshot.put("messageType", context.getMessageType() != null ? context.getMessageType().name() : null);
+        snapshot.put("eventTime", context.getEventTime());
+        snapshot.put("properties", context.getAllProperties().stream()
+            .collect(Collectors.toMap(
+                data -> data.getIdentifier(),
+                data -> data.getValue(),
+                (left, right) -> right,
+                LinkedHashMap::new
+            )));
+        context.getEventData().ifPresent(eventData -> {
+            snapshot.put("eventIdentifier", eventData.getIdentifier());
+            snapshot.put("eventParams", eventData.getParams().stream()
+                .collect(Collectors.toMap(
+                    data -> data.getIdentifier(),
+                    data -> data.getValue(),
+                    (left, right) -> right,
+                    LinkedHashMap::new
+                )));
+        });
+        snapshot.put("enrichedData", new LinkedHashMap<>(context.getEnrichedData()));
+        return snapshot;
+    }
+
+    private Map<String, Object> snapshotResult(RuleNodeExecutor.NodeResult result) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("success", result.success());
+        output.put("connectionType", result.connectionType());
+        output.put("message", result.message());
+        output.put("data", result.data());
+        return output;
     }
 
     private Map<String, List<Connection>> buildConnectionMap(List<RuleChain.RuleConnection> connections) {

--- a/iot-server/src/main/java/com/github/dingdaoyi/rule/RuleContext.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/rule/RuleContext.java
@@ -4,6 +4,7 @@ import com.github.dingdaoyi.proto.model.DecodeResult;
 import com.github.dingdaoyi.proto.model.DeviceData;
 import com.github.dingdaoyi.proto.model.tsl.TslModel;
 import com.github.dingdaoyi.proto.model.tsl.TslProperty;
+import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -117,10 +118,24 @@ public class RuleContext {
     }
 
     /**
-     * 添加执行轨迹
+     * 添加执行轨迹（兼容旧调用）。
      */
     public void addTrace(String nodeId, String nodeName, String connectionType, String detail) {
-        traces.add(new ExecutionTrace(nodeId, nodeName, connectionType, detail, LocalDateTime.now()));
+        traces.add(ExecutionTrace.builder()
+            .nodeId(nodeId)
+            .nodeName(nodeName)
+            .connectionType(connectionType)
+            .detail(detail)
+            .status("SUCCESS")
+            .timestamp(LocalDateTime.now())
+            .build());
+    }
+
+    /**
+     * 添加完整执行轨迹。
+     */
+    public void addTrace(ExecutionTrace trace) {
+        traces.add(trace);
     }
 
     /**
@@ -147,19 +162,18 @@ public class RuleContext {
     }
 
     @Data
+    @Builder
     public static class ExecutionTrace {
         private String nodeId;
         private String nodeName;
+        private String nodeType;
         private String connectionType;
+        private String status;
         private String detail;
+        private String error;
+        private Long durationMs;
+        private Map<String, Object> input;
+        private Map<String, Object> output;
         private LocalDateTime timestamp;
-
-        public ExecutionTrace(String nodeId, String nodeName, String connectionType, String detail, LocalDateTime timestamp) {
-            this.nodeId = nodeId;
-            this.nodeName = nodeName;
-            this.connectionType = connectionType;
-            this.detail = detail;
-            this.timestamp = timestamp;
-        }
     }
 }

--- a/iot-server/src/main/java/com/github/dingdaoyi/rule/RuleNodeExecutor.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/rule/RuleNodeExecutor.java
@@ -41,8 +41,8 @@ public interface RuleNodeExecutor {
             return new NodeResult(true, "Success", null, data);
         }
 
-        public static NodeResult ok(String connectionType) {
-            return new NodeResult(true, connectionType, null, null);
+        public static NodeResult ok(String message) {
+            return new NodeResult(true, "Success", message, null);
         }
 
         /**

--- a/iot-server/src/main/java/com/github/dingdaoyi/rule/node/HttpOutputNode.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/rule/node/HttpOutputNode.java
@@ -8,13 +8,12 @@ import com.github.dingdaoyi.rule.RuleNodeExecutor;
 import com.github.dingdaoyi.rule.config.NodeConfig;
 import com.github.dingdaoyi.rule.config.OutputHttpConfig;
 import com.github.dingdaoyi.service.PushConfigService;
+import com.github.dingdaoyi.service.push.HttpPushDeliveryService;
+import com.github.dingdaoyi.service.push.PushDeliveryResult;
 import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -32,7 +31,7 @@ public class HttpOutputNode implements RuleNodeExecutor {
     private PushConfigService pushConfigService;
 
     @Resource
-    private RestTemplate restTemplate;
+    private HttpPushDeliveryService httpPushDeliveryService;
 
     @Resource
     private ObjectMapper objectMapper;
@@ -67,22 +66,10 @@ public class HttpOutputNode implements RuleNodeExecutor {
         // 2. 构建模板变量
         Map<String, Object> variables = context.buildVariables();
 
-        // 3. 构建请求
-        String url = replaceTemplate(pushConfig.getHttpUrl(), variables);
-        String method = pushConfig.getHttpMethod() != null ? pushConfig.getHttpMethod() : "POST";
+        // 3. 构建模板化推送配置
+        PushConfig runtimeConfig = buildRuntimeConfig(pushConfig, variables);
 
-        // 4. 构建请求头
-        HttpHeaders headers = new HttpHeaders();
-        if (pushConfig.getHttpHeaders() != null) {
-            pushConfig.getHttpHeaders().forEach(kv ->
-                headers.set(kv.getKey(), replaceTemplate(kv.getValue(), variables)));
-        }
-        // 默认Content-Type
-        if (headers.getContentType() == null) {
-            headers.setContentType(MediaType.APPLICATION_JSON);
-        }
-
-        // 5. 构建请求体
+        // 4. 构建请求体
         String body;
         String customBody = cfg.getCustomBody();
         if (customBody != null) {
@@ -92,27 +79,36 @@ public class HttpOutputNode implements RuleNodeExecutor {
             body = buildDefaultBody(context, variables);
         }
 
-        // 6. 发送请求
-        try {
-            HttpEntity<String> entity = new HttpEntity<>(body, headers);
-
-            ResponseEntity<String> response;
-            if ("GET".equalsIgnoreCase(method)) {
-                response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
-            } else if ("PUT".equalsIgnoreCase(method)) {
-                response = restTemplate.exchange(url, HttpMethod.PUT, entity, String.class);
-            } else {
-                response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
-            }
-
+        // 5. 发送请求
+        PushDeliveryResult result = httpPushDeliveryService.deliverHttp(runtimeConfig, body, "rule.output.http");
+        if (result.isSuccess()) {
             String detail = String.format("HTTP推送 -> %s %s (状态: %s)",
-                    method, url, response.getStatusCode());
+                    runtimeConfig.getHttpMethod(), runtimeConfig.getHttpUrl(), result.getStatusCode());
             return NodeResult.ok(detail);
-
-        } catch (Exception e) {
-            log.error("HTTP推送失败: {} {}", method, url, e);
-            return NodeResult.fail("HTTP推送失败: " + e.getMessage());
         }
+        return NodeResult.fail(result.getMessage());
+    }
+
+    private PushConfig buildRuntimeConfig(PushConfig source, Map<String, Object> variables) {
+        PushConfig runtime = new PushConfig();
+        runtime.setId(source.getId());
+        runtime.setName(source.getName());
+        runtime.setType(source.getType());
+        runtime.setIsEnabled(source.getIsEnabled());
+        runtime.setHttpUrl(replaceTemplate(source.getHttpUrl(), variables));
+        runtime.setHttpMethod(source.getHttpMethod() != null ? source.getHttpMethod() : "POST");
+        runtime.setHttpTimeout(source.getHttpTimeout());
+        runtime.setHttpSignEnabled(source.getHttpSignEnabled());
+        runtime.setHttpSignSecret(source.getHttpSignSecret());
+        if (source.getHttpHeaders() != null) {
+            runtime.setHttpHeaders(source.getHttpHeaders().stream().map(kv -> {
+                PushConfig.KeyValue copied = new PushConfig.KeyValue();
+                copied.setKey(kv.getKey());
+                copied.setValue(replaceTemplate(kv.getValue(), variables));
+                return copied;
+            }).toList());
+        }
+        return runtime;
     }
 
     /**

--- a/iot-server/src/main/java/com/github/dingdaoyi/rule/node/ScriptFilterNode.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/rule/node/ScriptFilterNode.java
@@ -1,15 +1,26 @@
 package com.github.dingdaoyi.rule.node;
 
 import com.github.dingdaoyi.entity.enu.RuleNodeType;
+import com.github.dingdaoyi.proto.model.DeviceData;
 import com.github.dingdaoyi.rule.RuleContext;
 import com.github.dingdaoyi.rule.RuleNodeExecutor;
 import com.github.dingdaoyi.rule.config.FilterScriptConfig;
 import com.github.dingdaoyi.rule.config.NodeConfig;
+import org.apache.commons.lang3.StringUtils;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.PolyglotException;
+import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.proxy.ProxyObject;
 import org.springframework.stereotype.Component;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 /**
- * 脚本过滤节点
- * 使用简单表达式进行过滤
+ * 脚本过滤节点。
+ * 使用受限 GraalVM JavaScript 上下文执行返回 true/false 的过滤脚本。
+ *
  * @author dingyunwei
  */
 @Component
@@ -24,17 +35,84 @@ public class ScriptFilterNode implements RuleNodeExecutor {
     public NodeResult execute(RuleContext context, NodeConfig config) {
         FilterScriptConfig cfg = (FilterScriptConfig) config;
 
-        if (cfg == null || cfg.getScript() == null) {
-            return NodeResult.of(false, null, "未配置脚本");
+        if (cfg == null || StringUtils.isBlank(cfg.getScript())) {
+            return NodeResult.fail("未配置脚本");
+        }
+        String language = StringUtils.defaultIfBlank(cfg.getLanguage(), "javascript").toLowerCase();
+        if (!"javascript".equals(language) && !"js".equals(language)) {
+            return NodeResult.fail("暂仅支持 JavaScript 脚本过滤");
         }
 
-        String script = cfg.getScript();
+        try (Context jsContext = Context.newBuilder("js")
+                .allowAllAccess(false)
+                .option("engine.WarnInterpreterOnly", "false")
+                .build()) {
+            Value function = jsContext.eval("js", "(function(msg, device, enriched, ctx) {\n" + cfg.getScript() + "\n})");
+            Value value = function.execute(
+                    toJsObject(buildMessage(context)),
+                    toJsObject(buildDevice(context)),
+                    toJsObject(new LinkedHashMap<>(context.getEnrichedData())),
+                    toJsObject(buildContext(context))
+            );
+            boolean passed = value != null && !value.isNull() && value.asBoolean();
+            return new NodeResult(true, passed ? "True" : "False", "脚本返回 " + passed, Map.of(
+                    "result", passed,
+                    "language", "javascript"
+            ));
+        } catch (PolyglotException e) {
+            return NodeResult.fail("脚本执行失败: " + e.getMessage());
+        } catch (Exception e) {
+            return NodeResult.fail("脚本执行失败: " + e.getMessage());
+        }
+    }
 
-        // TODO: 实现脚本执行引擎
-        // 目前简单返回 true，后续可集成 Groovy/JavaScript 引擎
-        // Map<String, Object> variables = context.buildVariables();
-        // boolean result = scriptEngine.evaluate(script, variables);
+    private Map<String, Object> buildMessage(RuleContext context) {
+        Map<String, Object> msg = context.getAllProperties().stream()
+                .collect(Collectors.toMap(
+                        DeviceData::getIdentifier,
+                        DeviceData::getValue,
+                        (left, right) -> right,
+                        LinkedHashMap::new
+                ));
+        context.getEventData().ifPresent(eventData -> {
+            msg.put("eventIdentifier", eventData.getIdentifier());
+            Map<String, Object> params = eventData.getParams().stream()
+                    .collect(Collectors.toMap(
+                            DeviceData::getIdentifier,
+                            DeviceData::getValue,
+                            (left, right) -> right,
+                            LinkedHashMap::new
+                    ));
+            msg.put("eventParams", params);
+        });
+        msg.put("messageType", context.getMessageType() == null ? null : context.getMessageType().name());
+        return msg;
+    }
 
-        return NodeResult.of(true, "脚本通过: " + script, "脚本不通过");
+    private Map<String, Object> buildDevice(RuleContext context) {
+        Map<String, Object> device = new LinkedHashMap<>();
+        device.put("deviceKey", context.getDeviceKey());
+        device.put("deviceId", context.getDeviceId());
+        device.put("deviceName", context.getDeviceName());
+        return device;
+    }
+
+    private Map<String, Object> buildContext(RuleContext context) {
+        Map<String, Object> ctx = new LinkedHashMap<>();
+        ctx.put("device", buildDevice(context));
+        ctx.put("msg", buildMessage(context));
+        ctx.put("enriched", new LinkedHashMap<>(context.getEnrichedData()));
+        ctx.put("eventTime", context.getEventTime());
+        return ctx;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object toJsObject(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> converted = new LinkedHashMap<>();
+            map.forEach((key, item) -> converted.put(String.valueOf(key), toJsObject(item)));
+            return ProxyObject.fromMap(converted);
+        }
+        return value;
     }
 }

--- a/iot-server/src/main/java/com/github/dingdaoyi/service/ProtocolService.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/ProtocolService.java
@@ -3,8 +3,13 @@ package com.github.dingdaoyi.service;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.github.dingdaoyi.entity.Protocol;
 import com.baomidou.mybatisplus.extension.service.IService;
+import com.github.dingdaoyi.proto.model.DecodeResult;
+import com.github.dingdaoyi.proto.model.EncoderResult;
+import com.github.dingdaoyi.proto.model.ProtoMessageType;
+import com.github.dingdaoyi.proto.model.ProtocolException;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -37,5 +42,31 @@ public interface ProtocolService extends IService<Protocol>{
      * @return 是否成功
      */
     boolean setProtocolStatus(Integer id, boolean enable);
+
+    /**
+     * 测试脚本协议解码，不保存协议草稿，不影响当前已加载协议。
+     *
+     * @param protocol 协议草稿
+     * @param deviceKey 设备Key
+     * @param productKey 产品Key
+     * @param messageType 消息类型
+     * @param data 原始报文
+     * @return 解码结果
+     */
+    DecodeResult testDecode(Protocol protocol, String deviceKey, String productKey,
+                            ProtoMessageType messageType, String data) throws ProtocolException;
+
+    /**
+     * 测试脚本协议编码，不保存协议草稿，不影响当前已加载协议。
+     *
+     * @param protocol 协议草稿
+     * @param deviceKey 设备Key
+     * @param productKey 产品Key
+     * @param identifier 功能/属性标识符
+     * @param params 下行参数
+     * @return 编码结果
+     */
+    EncoderResult testEncode(Protocol protocol, String deviceKey, String productKey,
+                             String identifier, Map<String, Object> params) throws ProtocolException;
 
 }

--- a/iot-server/src/main/java/com/github/dingdaoyi/service/PushConfigService.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/PushConfigService.java
@@ -1,11 +1,13 @@
 package com.github.dingdaoyi.service;
 
 import com.baomidou.mybatisplus.extension.service.IService;
+import com.github.dingdaoyi.controller.iot.dto.PushTestRequest;
 import com.github.dingdaoyi.core.base.PageResult;
 import com.github.dingdaoyi.entity.PushConfig;
 import com.github.dingdaoyi.model.query.PushConfigPageQuery;
 import com.github.dingdaoyi.model.vo.PushConfigDetailVo;
 import com.github.dingdaoyi.model.vo.PushConfigPageVo;
+import com.github.dingdaoyi.service.push.PushDeliveryResult;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,4 +32,9 @@ public interface PushConfigService extends IService<PushConfig> {
      * 获取所有启用的配置
      */
     List<PushConfig> listEnabled();
+
+    /**
+     * 使用指定配置发送一次测试推送。
+     */
+    PushDeliveryResult testPush(Integer id, PushTestRequest request);
 }

--- a/iot-server/src/main/java/com/github/dingdaoyi/service/RuleChainService.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/RuleChainService.java
@@ -5,7 +5,9 @@ import com.github.dingdaoyi.core.base.PageResult;
 import com.github.dingdaoyi.entity.RuleChain;
 import com.github.dingdaoyi.model.query.RuleChainAddQuery;
 import com.github.dingdaoyi.model.query.RuleChainPageQuery;
+import com.github.dingdaoyi.controller.iot.dto.RuleChainDebugRequest;
 import com.github.dingdaoyi.model.query.RuleChainUpdateQuery;
+import com.github.dingdaoyi.model.vo.RuleChainDebugResultVo;
 import com.github.dingdaoyi.model.vo.RuleChainDetailVo;
 import com.github.dingdaoyi.model.vo.RuleChainPageVo;
 
@@ -53,4 +55,10 @@ public interface RuleChainService extends IService<RuleChain> {
      * 根据产品ID获取规则链
      */
     List<RuleChain> getByProductId(Integer productId);
+
+    /**
+     * 调试执行规则链草稿。
+     * 不要求先保存规则链，用于编辑器内模拟消息并查看节点执行轨迹。
+     */
+    RuleChainDebugResultVo debug(RuleChainDebugRequest request);
 }

--- a/iot-server/src/main/java/com/github/dingdaoyi/service/RuleChainService.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/RuleChainService.java
@@ -10,6 +10,7 @@ import com.github.dingdaoyi.model.query.RuleChainUpdateQuery;
 import com.github.dingdaoyi.model.vo.RuleChainDebugResultVo;
 import com.github.dingdaoyi.model.vo.RuleChainDetailVo;
 import com.github.dingdaoyi.model.vo.RuleChainPageVo;
+import com.github.dingdaoyi.model.vo.RuleChainValidationResultVo;
 
 import java.util.List;
 import java.util.Optional;
@@ -55,6 +56,11 @@ public interface RuleChainService extends IService<RuleChain> {
      * 根据产品ID获取规则链
      */
     List<RuleChain> getByProductId(Integer productId);
+
+    /**
+     * 校验规则链草稿结构。
+     */
+    RuleChainValidationResultVo validateDraft(RuleChain ruleChain);
 
     /**
      * 调试执行规则链草稿。

--- a/iot-server/src/main/java/com/github/dingdaoyi/service/impl/ProtocolServiceImpl.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/impl/ProtocolServiceImpl.java
@@ -2,10 +2,22 @@ package com.github.dingdaoyi.service.impl;
 
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.github.dingdaoyi.iot.proto.ProtocolFactory;
+import com.github.dingdaoyi.iot.proto.impl.ScriptProtocolInitialize.ScriptType;
+import com.github.dingdaoyi.iot.proto.script.ScriptProtocolDecoder;
+import com.github.dingdaoyi.proto.model.DecodeResult;
+import com.github.dingdaoyi.proto.model.DeviceRequest;
+import com.github.dingdaoyi.proto.model.EncoderMessage;
+import com.github.dingdaoyi.proto.model.EncoderResult;
+import com.github.dingdaoyi.proto.model.ExceptionType;
+import com.github.dingdaoyi.proto.model.ProtoMessageType;
+import com.github.dingdaoyi.proto.model.ProtocolException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
@@ -63,5 +75,66 @@ public class ProtocolServiceImpl extends ServiceImpl<ProtocolMapper, Protocol> i
         }
 
         return updated;
+    }
+
+    @Override
+    public DecodeResult testDecode(Protocol protocol, String deviceKey, String productKey,
+                                   ProtoMessageType messageType, String data) throws ProtocolException {
+        ScriptProtocolDecoder decoder = createDraftDecoder(protocol, deviceKey);
+
+        DeviceRequest request = new DeviceRequest();
+        request.setDeviceKey(StringUtils.defaultIfBlank(deviceKey, "debug-device"));
+        request.setProductKey(productKey);
+        request.setProtoKey(protocol.getProtoKey());
+        request.setMessageType(messageType == null ? ProtoMessageType.PROPERTY : messageType);
+        request.setData(StringUtils.defaultString(data).getBytes(StandardCharsets.UTF_8));
+
+        return decoder.decode(request, null);
+    }
+
+    @Override
+    public EncoderResult testEncode(Protocol protocol, String deviceKey, String productKey,
+                                    String identifier, Map<String, Object> params) throws ProtocolException {
+        ScriptProtocolDecoder decoder = createDraftDecoder(protocol, deviceKey);
+
+        EncoderMessage message = new EncoderMessage();
+        message.setDeviceKey(StringUtils.defaultIfBlank(deviceKey, "debug-device"));
+        message.setProductKey(productKey);
+        message.setIdentifier(identifier);
+        message.setParams(params == null ? Map.of() : params);
+
+        return decoder.encode(message, null);
+    }
+
+    private ScriptProtocolDecoder createDraftDecoder(Protocol protocol, String deviceKey) throws ProtocolException {
+        if (protocol == null) {
+            throw new ProtocolException(deviceKey, ExceptionType.INVALID_PARAM, -1, "协议草稿不能为空");
+        }
+        if (!protocol.isScriptType()) {
+            throw new ProtocolException(deviceKey, ExceptionType.INVALID_PARAM, -1, "仅支持脚本协议调试");
+        }
+        if (!protocol.hasScriptContent()) {
+            throw new ProtocolException(deviceKey, ExceptionType.INVALID_PARAM, -1, "脚本内容不能为空");
+        }
+
+        return new ScriptProtocolDecoder(
+                StringUtils.defaultIfBlank(protocol.getProtoKey(), "debug-script"),
+                StringUtils.defaultIfBlank(protocol.getName(), "脚本调试协议"),
+                protocol.getScriptContent(),
+                parseScriptType(protocol.getScriptLang())
+        );
+    }
+
+    private ScriptType parseScriptType(String scriptLang) {
+        if (StringUtils.isBlank(scriptLang)) {
+            return ScriptType.JAVASCRIPT;
+        }
+        return switch (scriptLang.toLowerCase()) {
+            case "js", "javascript" -> ScriptType.JAVASCRIPT;
+            case "py", "python" -> ScriptType.PYTHON;
+            case "groovy" -> ScriptType.GROOVY;
+            case "lua" -> ScriptType.LUA;
+            default -> ScriptType.JAVASCRIPT;
+        };
     }
 }

--- a/iot-server/src/main/java/com/github/dingdaoyi/service/impl/PushConfigServiceImpl.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/impl/PushConfigServiceImpl.java
@@ -3,14 +3,19 @@ package com.github.dingdaoyi.service.impl;
 import cn.hutool.core.bean.BeanUtil;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.github.dingdaoyi.controller.iot.dto.PushTestRequest;
 import com.github.dingdaoyi.core.base.PageResult;
 import com.github.dingdaoyi.entity.PushConfig;
+import com.github.dingdaoyi.entity.enu.PushConfigType;
 import com.github.dingdaoyi.mapper.PushConfigMapper;
 import com.github.dingdaoyi.model.query.PushConfigPageQuery;
 import com.github.dingdaoyi.model.vo.PushConfigDetailVo;
 import com.github.dingdaoyi.model.vo.PushConfigPageVo;
 import com.github.dingdaoyi.service.PushConfigService;
+import com.github.dingdaoyi.service.push.HttpPushDeliveryService;
+import com.github.dingdaoyi.service.push.PushDeliveryResult;
 import com.github.dingdaoyi.utils.PageHelper;
+import jakarta.annotation.Resource;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,6 +27,9 @@ import java.util.Optional;
  */
 @Service
 public class PushConfigServiceImpl extends ServiceImpl<PushConfigMapper, PushConfig> implements PushConfigService {
+
+    @Resource
+    private HttpPushDeliveryService httpPushDeliveryService;
 
     @Override
     public PageResult<PushConfigPageVo> pageByQuery(PushConfigPageQuery query) {
@@ -44,5 +52,30 @@ public class PushConfigServiceImpl extends ServiceImpl<PushConfigMapper, PushCon
     @Override
     public List<PushConfig> listEnabled() {
         return baseMapper.listEnabled();
+    }
+
+    @Override
+    public PushDeliveryResult testPush(Integer id, PushTestRequest request) {
+        PushConfig config = getById(id);
+        if (config == null) {
+            return PushDeliveryResult.failure("推送配置不存在: " + id);
+        }
+        if (!Boolean.TRUE.equals(config.getIsEnabled())) {
+            return PushDeliveryResult.failure("推送配置已禁用: " + config.getName());
+        }
+        if (config.getType() != PushConfigType.HTTP) {
+            return PushDeliveryResult.failure("当前仅支持 HTTP 推送配置测试");
+        }
+        Object payload = request != null && request.getPayload() != null ? request.getPayload() : defaultTestPayload();
+        String eventType = request != null && request.getEventType() != null ? request.getEventType() : "push.test";
+        return httpPushDeliveryService.deliverHttp(config, payload, eventType);
+    }
+
+    private Object defaultTestPayload() {
+        return java.util.Map.of(
+            "event", "push.test",
+            "deviceKey", "demo-device",
+            "properties", java.util.Map.of("temperature", 36.5)
+        );
     }
 }

--- a/iot-server/src/main/java/com/github/dingdaoyi/service/impl/RuleChainServiceImpl.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/impl/RuleChainServiceImpl.java
@@ -10,6 +10,7 @@ import com.github.dingdaoyi.core.base.PageResult;
 import com.github.dingdaoyi.entity.Device;
 import com.github.dingdaoyi.entity.Product;
 import com.github.dingdaoyi.entity.RuleChain;
+import com.github.dingdaoyi.entity.enu.RuleNodeType;
 import com.github.dingdaoyi.entity.enu.RuleSourceType;
 import com.github.dingdaoyi.mapper.RuleChainMapper;
 import com.github.dingdaoyi.model.query.RuleChainAddQuery;
@@ -18,6 +19,7 @@ import com.github.dingdaoyi.model.query.RuleChainUpdateQuery;
 import com.github.dingdaoyi.model.vo.RuleChainDebugResultVo;
 import com.github.dingdaoyi.model.vo.RuleChainDetailVo;
 import com.github.dingdaoyi.model.vo.RuleChainPageVo;
+import com.github.dingdaoyi.model.vo.RuleChainValidationResultVo;
 import com.github.dingdaoyi.proto.model.DataTypeEnum;
 import com.github.dingdaoyi.proto.model.DecodeResult;
 import com.github.dingdaoyi.proto.model.DeviceData;
@@ -32,10 +34,9 @@ import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * 规则链服务实现
@@ -125,6 +126,65 @@ public class RuleChainServiceImpl extends ServiceImpl<RuleChainMapper, RuleChain
     }
 
     @Override
+    public RuleChainValidationResultVo validateDraft(RuleChain ruleChain) {
+        RuleChainValidationResultVo result = new RuleChainValidationResultVo();
+        RuleChain.RuleChainConfiguration config = ruleChain == null ? null : ruleChain.getConfiguration();
+        if (config == null || CollectionUtil.isEmpty(config.getNodes())) {
+            result.addError("EMPTY_CHAIN", null, null, "规则链至少需要一个输入节点");
+            return result;
+        }
+
+        List<RuleChain.RuleNode> nodes = config.getNodes();
+        List<RuleChain.RuleConnection> connections = Optional.ofNullable(config.getConnections()).orElseGet(List::of);
+        Map<String, RuleChain.RuleNode> nodeMap = nodes.stream()
+            .filter(node -> node.getId() != null)
+            .collect(Collectors.toMap(RuleChain.RuleNode::getId, Function.identity(), (left, right) -> left, LinkedHashMap::new));
+
+        Set<String> inputNodeIds = new LinkedHashSet<>();
+        for (RuleChain.RuleNode node : nodes) {
+            RuleNodeType nodeType = parseNodeType(node.getType());
+            if (node.getId() == null) {
+                result.addError("NODE_ID_EMPTY", null, null, "节点ID不能为空");
+                continue;
+            }
+            if (nodeType == null) {
+                result.addError("UNKNOWN_NODE_TYPE", node.getId(), null, "未知节点类型: " + node.getType());
+                continue;
+            }
+            if (nodeType.getCategory() == RuleNodeType.NodeCategory.INPUT) {
+                inputNodeIds.add(node.getId());
+            }
+        }
+        if (inputNodeIds.isEmpty()) {
+            result.addError("NO_INPUT_NODE", null, null, "规则链至少需要一个输入节点");
+        }
+
+        Map<String, List<RuleChain.RuleConnection>> outgoing = new LinkedHashMap<>();
+        for (RuleChain.RuleConnection connection : connections) {
+            String connectionId = connection.getSource() + "->" + connection.getTarget() + ":" + connection.getType();
+            RuleChain.RuleNode source = nodeMap.get(connection.getSource());
+            RuleChain.RuleNode target = nodeMap.get(connection.getTarget());
+            if (source == null || target == null) {
+                result.addError("MISSING_NODE", null, connectionId, "连接引用的源节点或目标节点不存在");
+                continue;
+            }
+            if (!isValidConnection(source.getType(), target.getType())) {
+                result.addError("INVALID_CONNECTION", source.getId(), connectionId, getConnectionErrorMessage(source.getType(), target.getType()));
+            }
+            outgoing.computeIfAbsent(connection.getSource(), key -> new ArrayList<>()).add(connection);
+        }
+
+        Set<String> reachable = collectReachableNodeIds(inputNodeIds, outgoing);
+        result.setReachableNodeIds(new ArrayList<>(reachable));
+        for (RuleChain.RuleNode node : nodes) {
+            if (!reachable.contains(node.getId())) {
+                result.addWarning("UNREACHABLE_NODE", node.getId(), null, "节点未从任何输入节点连通，调试和运行时不会执行: " + Optional.ofNullable(node.getName()).orElse(node.getId()));
+            }
+        }
+        return result;
+    }
+
+    @Override
     public RuleChainDebugResultVo debug(RuleChainDebugRequest request) {
         RuleChain ruleChain = request.getRuleChain();
         if (ruleChain.getIsEnabled() == null) {
@@ -137,13 +197,37 @@ public class RuleChainServiceImpl extends ServiceImpl<RuleChainMapper, RuleChain
         long durationMs = (System.nanoTime() - start) / 1_000_000;
 
         RuleChainDebugResultVo result = new RuleChainDebugResultVo();
+        RuleChainValidationResultVo validation = validateDraft(ruleChain);
+        result.setValidation(validation);
         result.setRuleChainId(ruleChain.getId());
         result.setRuleChainName(ruleChain.getName());
         result.setDurationMs(durationMs);
         result.setTraces(context.getTraces());
         result.setExecutedNodeCount(context.getTraces().size());
-        result.setSuccess(context.getTraces().stream()
+        result.setExecutedConnections(buildExecutedConnections(ruleChain, context.getTraces()));
+        result.setSuccess(validation.isValid() && context.getTraces().stream()
             .noneMatch(trace -> "FAILED".equals(trace.getStatus()) || "ERROR".equals(trace.getStatus())));
+        return result;
+    }
+
+    private List<Map<String, String>> buildExecutedConnections(RuleChain ruleChain, List<RuleContext.ExecutionTrace> traces) {
+        RuleChain.RuleChainConfiguration config = ruleChain.getConfiguration();
+        if (config == null || CollectionUtil.isEmpty(config.getConnections()) || CollectionUtil.isEmpty(traces)) {
+            return List.of();
+        }
+        Map<String, RuleContext.ExecutionTrace> traceMap = traces.stream()
+            .collect(Collectors.toMap(RuleContext.ExecutionTrace::getNodeId, Function.identity(), (left, right) -> left, LinkedHashMap::new));
+        List<Map<String, String>> result = new ArrayList<>();
+        for (RuleChain.RuleConnection connection : config.getConnections()) {
+            RuleContext.ExecutionTrace sourceTrace = traceMap.get(connection.getSource());
+            if (sourceTrace != null && Objects.equals(connection.getType(), sourceTrace.getConnectionType()) && traceMap.containsKey(connection.getTarget())) {
+                result.add(Map.of(
+                    "source", connection.getSource(),
+                    "target", connection.getTarget(),
+                    "type", connection.getType()
+                ));
+            }
+        }
         return result;
     }
 
@@ -174,6 +258,97 @@ public class RuleChainServiceImpl extends ServiceImpl<RuleChainMapper, RuleChain
         }
         context.setDecodeResult(decodeResult);
         return context;
+    }
+
+    private Set<String> collectReachableNodeIds(Set<String> inputNodeIds, Map<String, List<RuleChain.RuleConnection>> outgoing) {
+        Set<String> visited = new LinkedHashSet<>();
+        Deque<String> queue = new ArrayDeque<>(inputNodeIds);
+        while (!queue.isEmpty()) {
+            String nodeId = queue.removeFirst();
+            if (!visited.add(nodeId)) {
+                continue;
+            }
+            for (RuleChain.RuleConnection connection : outgoing.getOrDefault(nodeId, List.of())) {
+                if (!visited.contains(connection.getTarget())) {
+                    queue.addLast(connection.getTarget());
+                }
+            }
+        }
+        return visited;
+    }
+
+    private RuleNodeType parseNodeType(String type) {
+        try {
+            return type == null ? null : RuleNodeType.valueOf(type);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private boolean isValidConnection(String sourceType, String targetType) {
+        RuleNodeType source = parseNodeType(sourceType);
+        RuleNodeType target = parseNodeType(targetType);
+        if (source == null || target == null) {
+            return false;
+        }
+        RuleNodeType.NodeCategory sourceCategory = source.getCategory();
+        RuleNodeType.NodeCategory targetCategory = target.getCategory();
+        if (targetCategory == RuleNodeType.NodeCategory.INPUT) {
+            return false;
+        }
+        if (sourceCategory == RuleNodeType.NodeCategory.OUTPUT) {
+            return false;
+        }
+        if (sourceCategory == RuleNodeType.NodeCategory.INPUT) {
+            if (source == RuleNodeType.INPUT_PROPERTY && target == RuleNodeType.FILTER_EVENT_TYPE) {
+                return false;
+            }
+            if (source == RuleNodeType.INPUT_EVENT && target == RuleNodeType.FILTER_PROPERTY) {
+                return false;
+            }
+            if (source == RuleNodeType.INPUT_ONLINE && targetCategory == RuleNodeType.NodeCategory.FILTER) {
+                return false;
+            }
+        }
+        if (sourceCategory == RuleNodeType.NodeCategory.FILTER) {
+            return targetCategory == RuleNodeType.NodeCategory.OUTPUT || targetCategory == RuleNodeType.NodeCategory.ALARM;
+        }
+        if (sourceCategory == RuleNodeType.NodeCategory.ALARM) {
+            return targetCategory == RuleNodeType.NodeCategory.OUTPUT;
+        }
+        return true;
+    }
+
+    private String getConnectionErrorMessage(String sourceType, String targetType) {
+        RuleNodeType source = parseNodeType(sourceType);
+        RuleNodeType target = parseNodeType(targetType);
+        if (source == null || target == null) {
+            return "连接包含未知节点类型";
+        }
+        RuleNodeType.NodeCategory sourceCategory = source.getCategory();
+        RuleNodeType.NodeCategory targetCategory = target.getCategory();
+        if (sourceCategory == RuleNodeType.NodeCategory.OUTPUT) {
+            return "输出节点是终端节点，不能继续连接";
+        }
+        if (targetCategory == RuleNodeType.NodeCategory.INPUT) {
+            return "输入节点不能作为连接目标";
+        }
+        if (source == RuleNodeType.INPUT_PROPERTY && target == RuleNodeType.FILTER_EVENT_TYPE) {
+            return "属性上报不能连接到事件类型过滤，请使用属性条件过滤";
+        }
+        if (source == RuleNodeType.INPUT_EVENT && target == RuleNodeType.FILTER_PROPERTY) {
+            return "事件上报不能连接到属性条件过滤，请使用事件类型过滤";
+        }
+        if (source == RuleNodeType.INPUT_ONLINE && targetCategory == RuleNodeType.NodeCategory.FILTER) {
+            return "设备上下线事件不能使用过滤节点，可直接连接告警或输出节点";
+        }
+        if (sourceCategory == RuleNodeType.NodeCategory.FILTER) {
+            return "过滤节点只能连接到输出或告警节点";
+        }
+        if (sourceCategory == RuleNodeType.NodeCategory.ALARM) {
+            return "告警节点只能连接到输出节点进行自定义推送";
+        }
+        return "此连接不被允许";
     }
 
     private DataTypeEnum inferDataType(Object value) {

--- a/iot-server/src/main/java/com/github/dingdaoyi/service/impl/RuleChainServiceImpl.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/impl/RuleChainServiceImpl.java
@@ -5,6 +5,7 @@ import cn.hutool.core.collection.CollectionUtil;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.github.dingdaoyi.controller.iot.dto.RuleChainDebugRequest;
 import com.github.dingdaoyi.core.base.PageResult;
 import com.github.dingdaoyi.entity.Device;
 import com.github.dingdaoyi.entity.Product;
@@ -14,8 +15,15 @@ import com.github.dingdaoyi.mapper.RuleChainMapper;
 import com.github.dingdaoyi.model.query.RuleChainAddQuery;
 import com.github.dingdaoyi.model.query.RuleChainPageQuery;
 import com.github.dingdaoyi.model.query.RuleChainUpdateQuery;
+import com.github.dingdaoyi.model.vo.RuleChainDebugResultVo;
 import com.github.dingdaoyi.model.vo.RuleChainDetailVo;
 import com.github.dingdaoyi.model.vo.RuleChainPageVo;
+import com.github.dingdaoyi.proto.model.DataTypeEnum;
+import com.github.dingdaoyi.proto.model.DecodeResult;
+import com.github.dingdaoyi.proto.model.DeviceData;
+import com.github.dingdaoyi.proto.model.DeviceEventData;
+import com.github.dingdaoyi.rule.RuleChainEngine;
+import com.github.dingdaoyi.rule.RuleContext;
 import com.github.dingdaoyi.service.DeviceService;
 import com.github.dingdaoyi.service.ProductService;
 import com.github.dingdaoyi.service.RuleChainService;
@@ -26,6 +34,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -41,6 +50,9 @@ public class RuleChainServiceImpl extends ServiceImpl<RuleChainMapper, RuleChain
 
     @Resource
     private ProductService productService;
+
+    @Resource
+    private RuleChainEngine ruleChainEngine;
 
     @Override
     public PageResult<RuleChainPageVo> pageByQuery(RuleChainPageQuery query) {
@@ -110,6 +122,74 @@ public class RuleChainServiceImpl extends ServiceImpl<RuleChainMapper, RuleChain
             .eq(RuleChain::getIsEnabled, true)
             .eq(RuleChain::getSourceType, RuleSourceType.PRODUCT)
             .eq(RuleChain::getSourceId, productId));
+    }
+
+    @Override
+    public RuleChainDebugResultVo debug(RuleChainDebugRequest request) {
+        RuleChain ruleChain = request.getRuleChain();
+        if (ruleChain.getIsEnabled() == null) {
+            ruleChain.setIsEnabled(true);
+        }
+
+        RuleContext context = buildDebugContext(request);
+        long start = System.nanoTime();
+        ruleChainEngine.execute(ruleChain, context);
+        long durationMs = (System.nanoTime() - start) / 1_000_000;
+
+        RuleChainDebugResultVo result = new RuleChainDebugResultVo();
+        result.setRuleChainId(ruleChain.getId());
+        result.setRuleChainName(ruleChain.getName());
+        result.setDurationMs(durationMs);
+        result.setTraces(context.getTraces());
+        result.setExecutedNodeCount(context.getTraces().size());
+        result.setSuccess(context.getTraces().stream()
+            .noneMatch(trace -> "FAILED".equals(trace.getStatus()) || "ERROR".equals(trace.getStatus())));
+        return result;
+    }
+
+    private RuleContext buildDebugContext(RuleChainDebugRequest request) {
+        RuleContext context = new RuleContext();
+        context.setDeviceKey(request.getDeviceKey());
+        context.setDeviceId(request.getDeviceId());
+        context.setDeviceName(request.getDeviceName());
+        context.setMessageType(request.getMessageType());
+        if (request.getEnrichedData() != null) {
+            context.getEnrichedData().putAll(request.getEnrichedData());
+        }
+
+        DecodeResult decodeResult = new DecodeResult();
+        if (request.getProperties() != null) {
+            request.getProperties().forEach((identifier, value) ->
+                decodeResult.getDataList().add(new DeviceData(identifier, inferDataType(value), value))
+            );
+        }
+        if (request.getEventIdentifier() != null) {
+            DeviceEventData eventData = new DeviceEventData(request.getEventIdentifier(), null);
+            if (request.getEventParams() != null) {
+                request.getEventParams().forEach((identifier, value) ->
+                    eventData.getParams().add(new DeviceData(identifier, inferDataType(value), value))
+                );
+            }
+            decodeResult.setEventData(eventData);
+        }
+        context.setDecodeResult(decodeResult);
+        return context;
+    }
+
+    private DataTypeEnum inferDataType(Object value) {
+        if (value instanceof Boolean) {
+            return DataTypeEnum.BOOL;
+        }
+        if (value instanceof Float || value instanceof Double || value instanceof java.math.BigDecimal) {
+            return DataTypeEnum.DOUBLE;
+        }
+        if (value instanceof Number) {
+            return DataTypeEnum.INT;
+        }
+        if (value instanceof Map<?, ?>) {
+            return DataTypeEnum.STRUCT;
+        }
+        return DataTypeEnum.TEXT;
     }
 
     private void fillSourceName(RuleChainDetailVo vo, RuleChain ruleChain) {

--- a/iot-server/src/main/java/com/github/dingdaoyi/service/push/HttpPushDeliveryService.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/push/HttpPushDeliveryService.java
@@ -1,0 +1,114 @@
+package com.github.dingdaoyi.service.push;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dingdaoyi.entity.PushConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Clock;
+import java.util.Map;
+
+/**
+ * Sends HTTP webhook pushes with optional Simple IoT HMAC signature headers.
+ */
+@Slf4j
+@Service
+public class HttpPushDeliveryService {
+
+    public static final String HEADER_TIMESTAMP = "X-Simple-IoT-Timestamp";
+    public static final String HEADER_SIGNATURE = "X-Simple-IoT-Signature";
+    public static final String HEADER_SIGNATURE_METHOD = "X-Simple-IoT-Signature-Method";
+    public static final String HEADER_EVENT = "X-Simple-IoT-Event";
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final PushWebhookSigner signer;
+    private final PushEndpointGuard endpointGuard;
+    private final Clock clock;
+
+    @Autowired
+    public HttpPushDeliveryService(RestTemplate restTemplate,
+                                   ObjectMapper objectMapper,
+                                   PushWebhookSigner signer,
+                                   PushEndpointGuard endpointGuard) {
+        this(restTemplate, objectMapper, signer, endpointGuard, Clock.systemUTC());
+    }
+
+    HttpPushDeliveryService(RestTemplate restTemplate,
+                            ObjectMapper objectMapper,
+                            PushWebhookSigner signer,
+                            PushEndpointGuard endpointGuard,
+                            Clock clock) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+        this.signer = signer;
+        this.endpointGuard = endpointGuard;
+        this.clock = clock;
+    }
+
+    public PushDeliveryResult deliverHttp(PushConfig config, Object payload, String eventType) {
+        String body = stringifyPayload(payload);
+        return deliverHttp(config, body, eventType);
+    }
+
+    public PushDeliveryResult deliverHttp(PushConfig config, String body, String eventType) {
+        String method = config.getHttpMethod() != null ? config.getHttpMethod() : "POST";
+        String url = config.getHttpUrl();
+        try {
+            endpointGuard.validate(url);
+            HttpHeaders headers = buildHeaders(config, body, eventType);
+            HttpEntity<String> entity = new HttpEntity<>(body == null ? "" : body, headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.valueOf(method.toUpperCase()), entity, String.class);
+            String message = String.format("HTTP推送成功: %s %s -> %s", method.toUpperCase(), url, response.getStatusCode());
+            return PushDeliveryResult.success(response.getStatusCode().value(), message, response.getBody());
+        } catch (Exception e) {
+            log.error("HTTP推送失败: {} {}", method, url, e);
+            return PushDeliveryResult.failure("HTTP推送失败: " + e.getMessage());
+        }
+    }
+
+    private HttpHeaders buildHeaders(PushConfig config, String body, String eventType) {
+        HttpHeaders headers = new HttpHeaders();
+        if (config.getHttpHeaders() != null) {
+            config.getHttpHeaders().forEach(kv -> {
+                if (kv.getKey() != null && !kv.getKey().isBlank()) {
+                    headers.set(kv.getKey(), kv.getValue() == null ? "" : kv.getValue());
+                }
+            });
+        }
+        if (headers.getContentType() == null) {
+            headers.setContentType(MediaType.APPLICATION_JSON);
+        }
+        if (eventType != null && !eventType.isBlank()) {
+            headers.set(HEADER_EVENT, eventType);
+        }
+        if (Boolean.TRUE.equals(config.getHttpSignEnabled()) && config.getHttpSignSecret() != null && !config.getHttpSignSecret().isBlank()) {
+            String timestamp = String.valueOf(clock.millis());
+            headers.set(HEADER_TIMESTAMP, timestamp);
+            headers.set(HEADER_SIGNATURE, signer.sign(config.getHttpSignSecret(), timestamp, body));
+            headers.set(HEADER_SIGNATURE_METHOD, "HMAC-SHA256");
+        }
+        return headers;
+    }
+
+    private String stringifyPayload(Object payload) {
+        if (payload == null) {
+            return "";
+        }
+        if (payload instanceof String text) {
+            return text;
+        }
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (Exception e) {
+            if (payload instanceof Map<?, ?>) {
+                return "{}";
+            }
+            return String.valueOf(payload);
+        }
+    }
+}

--- a/iot-server/src/main/java/com/github/dingdaoyi/service/push/PushDeliveryResult.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/push/PushDeliveryResult.java
@@ -1,0 +1,27 @@
+package com.github.dingdaoyi.service.push;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Result of a push delivery attempt.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushDeliveryResult {
+
+    private boolean success;
+    private Integer statusCode;
+    private String message;
+    private String responseBody;
+
+    public static PushDeliveryResult success(Integer statusCode, String message, String responseBody) {
+        return new PushDeliveryResult(true, statusCode, message, responseBody);
+    }
+
+    public static PushDeliveryResult failure(String message) {
+        return new PushDeliveryResult(false, null, message, null);
+    }
+}

--- a/iot-server/src/main/java/com/github/dingdaoyi/service/push/PushEndpointGuard.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/push/PushEndpointGuard.java
@@ -1,0 +1,47 @@
+package com.github.dingdaoyi.service.push;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.InetAddress;
+import java.net.URI;
+
+/**
+ * Guard for outgoing webhook endpoints to reduce SSRF risk.
+ */
+@Component
+public class PushEndpointGuard {
+
+    private final boolean allowPrivateEndpoints;
+
+    public PushEndpointGuard(@Value("${simple-iot.push.allow-private-endpoints:false}") boolean allowPrivateEndpoints) {
+        this.allowPrivateEndpoints = allowPrivateEndpoints;
+    }
+
+    public void validate(String url) {
+        try {
+            URI uri = URI.create(url);
+            if (!"http".equalsIgnoreCase(uri.getScheme()) && !"https".equalsIgnoreCase(uri.getScheme())) {
+                throw new IllegalArgumentException("仅支持 HTTP/HTTPS 推送地址");
+            }
+            if (allowPrivateEndpoints) {
+                return;
+            }
+            String host = uri.getHost();
+            if (host == null || host.isBlank()) {
+                throw new IllegalArgumentException("推送地址无效");
+            }
+            InetAddress address = InetAddress.getByName(host);
+            if (address.isAnyLocalAddress()
+                || address.isLoopbackAddress()
+                || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress()) {
+                throw new IllegalArgumentException("不允许推送到内网或本机地址，请配置 simple-iot.push.allow-private-endpoints=true 后仅在可信环境使用");
+            }
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("推送地址解析失败: " + e.getMessage(), e);
+        }
+    }
+}

--- a/iot-server/src/main/java/com/github/dingdaoyi/service/push/PushWebhookSigner.java
+++ b/iot-server/src/main/java/com/github/dingdaoyi/service/push/PushWebhookSigner.java
@@ -1,0 +1,28 @@
+package com.github.dingdaoyi.service.push;
+
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+/**
+ * HMAC-SHA256 signer for outgoing HTTP webhook pushes.
+ */
+@Component
+public class PushWebhookSigner {
+
+    private static final String HMAC_SHA256 = "HmacSHA256";
+
+    public String sign(String secret, String timestamp, String body) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_SHA256);
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
+            String payload = timestamp + "." + (body == null ? "" : body);
+            return HexFormat.of().formatHex(mac.doFinal(payload.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException("Webhook 签名生成失败", e);
+        }
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/controller/iot/ProtocolControllerScriptTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/controller/iot/ProtocolControllerScriptTest.java
@@ -1,0 +1,87 @@
+package com.github.dingdaoyi.controller.iot;
+
+import com.github.dingdaoyi.controller.iot.dto.ProtocolDecodeTestRequest;
+import com.github.dingdaoyi.controller.iot.dto.ProtocolEncodeTestRequest;
+import com.github.dingdaoyi.core.base.BaseResult;
+import com.github.dingdaoyi.entity.Protocol;
+import com.github.dingdaoyi.entity.enu.ProtoType;
+import com.github.dingdaoyi.proto.model.DecodeResult;
+import com.github.dingdaoyi.proto.model.EncoderResult;
+import com.github.dingdaoyi.proto.model.ProtoMessageType;
+import com.github.dingdaoyi.service.ProductService;
+import com.github.dingdaoyi.service.ProtocolService;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProtocolControllerScriptTest {
+
+    private final ProtocolService protocolService = mock(ProtocolService.class);
+    private final ProductService productService = mock(ProductService.class);
+    private final ProtocolController controller = new ProtocolController(protocolService, productService);
+
+    @Test
+    void testDecodeDelegatesDraftRequestToProtocolService() throws Exception {
+        Protocol protocol = scriptProtocol();
+        DecodeResult decodeResult = new DecodeResult();
+        decodeResult.setMessageId(1001);
+        decodeResult.setRowData("{\"temperature\":25.5}");
+
+        when(protocolService.testDecode(protocol, "device-001", "product-a", ProtoMessageType.PROPERTY, "{\"temperature\":25.5}"))
+                .thenReturn(decodeResult);
+
+        ProtocolDecodeTestRequest request = new ProtocolDecodeTestRequest();
+        request.setProtocol(protocol);
+        request.setDeviceKey("device-001");
+        request.setProductKey("product-a");
+        request.setMessageType(ProtoMessageType.PROPERTY);
+        request.setData("{\"temperature\":25.5}");
+
+        BaseResult<?> response = controller.testDecode(request);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData()).isSameAs(decodeResult);
+        verify(protocolService).testDecode(protocol, "device-001", "product-a", ProtoMessageType.PROPERTY, "{\"temperature\":25.5}");
+    }
+
+    @Test
+    void testEncodeDelegatesDraftRequestToProtocolService() throws Exception {
+        Protocol protocol = scriptProtocol();
+        Map<String, Object> params = Map.of("power", "on");
+        EncoderResult encoderResult = new EncoderResult();
+        encoderResult.setMessageId(2002);
+        encoderResult.setMessage("{\"power\":\"on\"}".getBytes(StandardCharsets.UTF_8));
+
+        when(protocolService.testEncode(protocol, "device-001", "product-a", "setPower", params))
+                .thenReturn(encoderResult);
+
+        ProtocolEncodeTestRequest request = new ProtocolEncodeTestRequest();
+        request.setProtocol(protocol);
+        request.setDeviceKey("device-001");
+        request.setProductKey("product-a");
+        request.setIdentifier("setPower");
+        request.setParams(params);
+
+        BaseResult<?> response = controller.testEncode(request);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData()).isSameAs(encoderResult);
+        verify(protocolService).testEncode(protocol, "device-001", "product-a", "setPower", params);
+    }
+
+    private Protocol scriptProtocol() {
+        Protocol protocol = new Protocol();
+        protocol.setName("JS Debug");
+        protocol.setProtoKey("js-debug");
+        protocol.setProtoType(ProtoType.JAVASCRIPT);
+        protocol.setScriptLang("javascript");
+        protocol.setScriptContent("exports.decode = function() { return { dataList: [] }; }; exports.encode = function() { return { message: '{}' }; };");
+        return protocol;
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/controller/iot/PushConfigControllerTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/controller/iot/PushConfigControllerTest.java
@@ -1,0 +1,33 @@
+package com.github.dingdaoyi.controller.iot;
+
+import com.github.dingdaoyi.controller.iot.dto.PushTestRequest;
+import com.github.dingdaoyi.core.base.BaseResult;
+import com.github.dingdaoyi.service.PushConfigService;
+import com.github.dingdaoyi.service.push.PushDeliveryResult;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PushConfigControllerTest {
+
+    private final PushConfigService pushConfigService = mock(PushConfigService.class);
+    private final PushConfigController controller = new PushConfigController(pushConfigService);
+
+    @Test
+    void testPushDelegatesToServiceAndReturnsDeliveryResult() {
+        PushTestRequest request = new PushTestRequest();
+        request.setPayload("{\"temperature\":36.5}");
+        request.setEventType("push.test");
+        PushDeliveryResult result = PushDeliveryResult.success(200, "HTTP推送成功", "ok");
+        when(pushConfigService.testPush(10, request)).thenReturn(result);
+
+        BaseResult<PushDeliveryResult> response = controller.testPush(10, request);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData()).isSameAs(result);
+        verify(pushConfigService).testPush(10, request);
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/controller/iot/RuleChainControllerDebugTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/controller/iot/RuleChainControllerDebugTest.java
@@ -1,0 +1,51 @@
+package com.github.dingdaoyi.controller.iot;
+
+import com.github.dingdaoyi.controller.iot.dto.RuleChainDebugRequest;
+import com.github.dingdaoyi.core.base.BaseResult;
+import com.github.dingdaoyi.entity.RuleChain;
+import com.github.dingdaoyi.model.vo.RuleChainDebugResultVo;
+import com.github.dingdaoyi.rule.RuleContext;
+import com.github.dingdaoyi.service.ProductService;
+import com.github.dingdaoyi.service.RuleChainService;
+import com.github.dingdaoyi.service.TslModelService;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RuleChainControllerDebugTest {
+
+    private final RuleChainService ruleChainService = mock(RuleChainService.class);
+    private final ProductService productService = mock(ProductService.class);
+    private final TslModelService tslModelService = mock(TslModelService.class);
+    private final RuleChainController controller = new RuleChainController(ruleChainService, productService, tslModelService);
+
+    @Test
+    void debugDelegatesDraftRuleChainToService() {
+        RuleChainDebugRequest request = new RuleChainDebugRequest();
+        RuleChain ruleChain = new RuleChain();
+        ruleChain.setName("草稿规则链");
+        request.setRuleChain(ruleChain);
+        request.setMessageType(RuleContext.MessageType.PROPERTY);
+        request.setProperties(Map.of("temperature", 36.5));
+
+        RuleChainDebugResultVo result = new RuleChainDebugResultVo();
+        result.setRuleChainName("草稿规则链");
+        result.setSuccess(true);
+        result.setExecutedNodeCount(1);
+        result.setTraces(List.of());
+
+        when(ruleChainService.debug(request)).thenReturn(result);
+
+        BaseResult<RuleChainDebugResultVo> response = controller.debug(request);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData()).isSameAs(result);
+        verify(ruleChainService).debug(request);
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/controller/iot/RuleChainControllerDebugTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/controller/iot/RuleChainControllerDebugTest.java
@@ -4,6 +4,7 @@ import com.github.dingdaoyi.controller.iot.dto.RuleChainDebugRequest;
 import com.github.dingdaoyi.core.base.BaseResult;
 import com.github.dingdaoyi.entity.RuleChain;
 import com.github.dingdaoyi.model.vo.RuleChainDebugResultVo;
+import com.github.dingdaoyi.model.vo.RuleChainValidationResultVo;
 import com.github.dingdaoyi.rule.RuleContext;
 import com.github.dingdaoyi.service.ProductService;
 import com.github.dingdaoyi.service.RuleChainService;
@@ -47,5 +48,21 @@ class RuleChainControllerDebugTest {
         assertThat(response.isSuccess()).isTrue();
         assertThat(response.getData()).isSameAs(result);
         verify(ruleChainService).debug(request);
+    }
+
+    @Test
+    void validateDelegatesDraftRuleChainToService() {
+        RuleChain ruleChain = new RuleChain();
+        ruleChain.setName("草稿规则链");
+        RuleChainValidationResultVo result = new RuleChainValidationResultVo();
+        result.setValid(true);
+
+        when(ruleChainService.validateDraft(ruleChain)).thenReturn(result);
+
+        BaseResult<RuleChainValidationResultVo> response = controller.validate(ruleChain);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData()).isSameAs(result);
+        verify(ruleChainService).validateDraft(ruleChain);
     }
 }

--- a/iot-server/src/test/java/com/github/dingdaoyi/iot/proto/script/ScriptProtocolDecoderTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/iot/proto/script/ScriptProtocolDecoderTest.java
@@ -1,0 +1,185 @@
+package com.github.dingdaoyi.iot.proto.script;
+
+import com.github.dingdaoyi.iot.proto.impl.ScriptProtocolInitialize.ScriptType;
+import com.github.dingdaoyi.proto.model.DataTypeEnum;
+import com.github.dingdaoyi.proto.model.DecodeResult;
+import com.github.dingdaoyi.proto.model.DeviceRequest;
+import com.github.dingdaoyi.proto.model.EncoderMessage;
+import com.github.dingdaoyi.proto.model.EncoderResult;
+import com.github.dingdaoyi.proto.model.ProtoMessageType;
+import com.github.dingdaoyi.proto.model.ProtocolException;
+import com.github.dingdaoyi.proto.model.tsl.EventTypeEnum;
+import com.github.dingdaoyi.proto.model.tsl.TslModel;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ScriptProtocolDecoderTest {
+
+    @Test
+    void javascriptDecodeMapsPropertyDataListWithTypedValues() throws ProtocolException {
+        ScriptProtocolDecoder decoder = decoder("""
+                exports.decode = function(request) {
+                  const data = JSON.parse(request.data);
+                  return {
+                    messageId: 101,
+                    rawData: request.data,
+                    dataList: [
+                      { identifier: 'temperature', type: 'DOUBLE', value: data.temperature },
+                      { identifier: 'online', type: 'BOOL', value: data.online },
+                      { identifier: 'mode', type: 'TEXT', value: data.mode },
+                      { identifier: 'settings', type: 'STRUCT', value: { threshold: data.threshold } }
+                    ]
+                  };
+                };
+                """);
+
+        DecodeResult result = decoder.decode(request(ProtoMessageType.PROPERTY,
+                "{\"temperature\":26.5,\"online\":true,\"mode\":\"auto\",\"threshold\":30}"), new TslModel());
+
+        assertThat(result.getMessageId()).isEqualTo(101);
+        assertThat(result.getRowData()).contains("temperature");
+        assertThat(result.getDataList()).hasSize(4);
+        assertThat(result.getDataList().get(0).getIdentifier()).isEqualTo("temperature");
+        assertThat(result.getDataList().get(0).getDataType()).isEqualTo(DataTypeEnum.DOUBLE);
+        assertThat(result.getDataList().get(0).getValue()).isEqualTo(26.5);
+        assertThat(result.getDataList().get(1).getDataType()).isEqualTo(DataTypeEnum.BOOL);
+        assertThat(result.getDataList().get(1).getValue()).isEqualTo(true);
+        assertThat(result.getDataList().get(3).getDataType()).isEqualTo(DataTypeEnum.STRUCT);
+        assertThat(result.getDataList().get(3).getValue()).isInstanceOf(Map.class);
+    }
+
+    @Test
+    void javascriptDecodeMapsEventDataAndParameters() throws ProtocolException {
+        ScriptProtocolDecoder decoder = decoder("""
+                exports.decode = function(request) {
+                  const data = JSON.parse(request.data);
+                  return {
+                    messageId: 202,
+                    eventData: {
+                      eventIdentifier: 'overheat',
+                      eventType: 'WARN',
+                      params: [
+                        { identifier: 'temperature', type: 'DOUBLE', value: data.temperature },
+                        { identifier: 'reason', type: 'TEXT', value: data.reason }
+                      ]
+                    }
+                  };
+                };
+                """);
+
+        DecodeResult result = decoder.decode(request(ProtoMessageType.EVENT,
+                "{\"temperature\":72.3,\"reason\":\"too hot\"}"), new TslModel());
+
+        assertThat(result.getMessageId()).isEqualTo(202);
+        assertThat(result.getEventData()).isNotNull();
+        assertThat(result.getEventData().getIdentifier()).isEqualTo("overheat");
+        assertThat(result.getEventData().getEventType()).isEqualTo(EventTypeEnum.WARN);
+        assertThat(result.getEventData().getParams()).hasSize(2);
+        assertThat(result.getEventData().getParams().get(0).getIdentifier()).isEqualTo("temperature");
+        assertThat(result.getEventData().getParams().get(0).getDataType()).isEqualTo(DataTypeEnum.DOUBLE);
+    }
+
+    @Test
+    void javascriptDecodeMapsServiceResponseData() throws ProtocolException {
+        ScriptProtocolDecoder decoder = decoder("""
+                exports.decode = function() {
+                  return {
+                    messageId: 303,
+                    serviceResData: {
+                      serviceIdentifier: 'setPower',
+                      resultData: [
+                        { identifier: 'success', type: 'BOOL', value: true },
+                        { identifier: 'message', type: 'TEXT', value: 'ok' }
+                      ]
+                    }
+                  };
+                };
+                """);
+
+        DecodeResult result = decoder.decode(request(ProtoMessageType.SERVICE_RES, "{}"), new TslModel());
+
+        assertThat(result.getMessageId()).isEqualTo(303);
+        assertThat(result.getServiceResData()).isNotNull();
+        assertThat(result.getServiceResData().getIdentifier()).isEqualTo("setPower");
+        assertThat(result.getServiceResData().getResultData()).hasSize(2);
+        assertThat(result.getServiceResData().toMap()).containsEntry("success", true).containsEntry("message", "ok");
+    }
+
+    @Test
+    void javascriptEncodeMapsMessageBytesMetadataAndNeedReply() throws ProtocolException {
+        ScriptProtocolDecoder decoder = decoder("""
+                exports.encode = function(message) {
+                  return {
+                    messageId: 404,
+                    message: JSON.stringify({ id: message.identifier, params: message.params, deviceKey: message.deviceKey }),
+                    needReply: false,
+                    metadata: {
+                      topic: '/device/' + message.deviceKey + '/command',
+                      qos: 1
+                    }
+                  };
+                };
+                """);
+        EncoderMessage message = new EncoderMessage();
+        message.setIdentifier("setPower");
+        message.setDeviceKey("device-js-001");
+        message.setProductKey("product-js");
+        message.setParams(Map.of("power", "on"));
+
+        EncoderResult result = decoder.encode(message, new TslModel());
+
+        assertThat(result.getMessageId()).isEqualTo(404);
+        assertThat(new String(result.getMessage(), StandardCharsets.UTF_8))
+                .contains("setPower")
+                .contains("device-js-001")
+                .contains("power");
+        assertThat(result.isNeedReply()).isFalse();
+        assertThat(result.getMetadata()).containsEntry("topic", "/device/device-js-001/command")
+                .containsEntry("qos", 1L);
+    }
+
+    @Test
+    void javascriptDecodeThrowsReadableProtocolExceptionWhenDecodeFunctionMissing() {
+        ScriptProtocolDecoder decoder = decoder("""
+                exports.encode = function() {
+                  return { message: 'ok' };
+                };
+                """);
+
+        assertThatThrownBy(() -> decoder.decode(request(ProtoMessageType.PROPERTY, "{}"), new TslModel()))
+                .isInstanceOf(ProtocolException.class)
+                .hasMessageContaining("decode");
+    }
+
+    @Test
+    void javascriptDecodeWrapsScriptErrorsAsProtocolException() {
+        ScriptProtocolDecoder decoder = decoder("""
+                exports.decode = function() {
+                  throw new Error('boom from js');
+                };
+                """);
+
+        assertThatThrownBy(() -> decoder.decode(request(ProtoMessageType.PROPERTY, "{}"), new TslModel()))
+                .isInstanceOf(ProtocolException.class)
+                .hasMessageContaining("boom from js");
+    }
+
+    private ScriptProtocolDecoder decoder(String script) {
+        return new ScriptProtocolDecoder("js-demo", "JS Demo", script, ScriptType.JAVASCRIPT);
+    }
+
+    private DeviceRequest request(ProtoMessageType messageType, String payload) {
+        DeviceRequest request = new DeviceRequest();
+        request.setDeviceKey("device-js-001");
+        request.setProductKey("product-js");
+        request.setProtoKey("js-demo");
+        request.setMessageType(messageType);
+        request.setData(payload.getBytes(StandardCharsets.UTF_8));
+        return request;
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/rule/node/ScriptFilterNodeTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/rule/node/ScriptFilterNodeTest.java
@@ -1,0 +1,77 @@
+package com.github.dingdaoyi.rule.node;
+
+import com.github.dingdaoyi.proto.model.DataTypeEnum;
+import com.github.dingdaoyi.proto.model.DecodeResult;
+import com.github.dingdaoyi.proto.model.DeviceData;
+import com.github.dingdaoyi.rule.RuleContext;
+import com.github.dingdaoyi.rule.RuleNodeExecutor;
+import com.github.dingdaoyi.rule.config.FilterScriptConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScriptFilterNodeTest {
+
+    private final ScriptFilterNode node = new ScriptFilterNode();
+
+    @Test
+    void javascriptFilterReturnsTrueWhenScriptExpressionMatchesContext() {
+        FilterScriptConfig config = config("return msg.temperature > 30 && device.deviceKey === 'device-001' && enriched.tenant === 'demo';");
+        RuleContext context = context(Map.of("temperature", 36.5), Map.of("tenant", "demo"));
+
+        RuleNodeExecutor.NodeResult result = node.execute(context, config);
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.connectionType()).isEqualTo("True");
+        assertThat(result.message()).contains("脚本返回 true");
+        assertThat(result.data()).containsEntry("result", true);
+    }
+
+    @Test
+    void javascriptFilterReturnsFalseWhenScriptExpressionDoesNotMatchContext() {
+        FilterScriptConfig config = config("return msg.temperature > 50;");
+        RuleContext context = context(Map.of("temperature", 36.5), Map.of());
+
+        RuleNodeExecutor.NodeResult result = node.execute(context, config);
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.connectionType()).isEqualTo("False");
+        assertThat(result.message()).contains("脚本返回 false");
+        assertThat(result.data()).containsEntry("result", false);
+    }
+
+    @Test
+    void javascriptFilterReportsFailureWhenScriptThrows() {
+        FilterScriptConfig config = config("throw new Error('bad script');");
+        RuleContext context = context(Map.of("temperature", 36.5), Map.of());
+
+        RuleNodeExecutor.NodeResult result = node.execute(context, config);
+
+        assertThat(result.success()).isFalse();
+        assertThat(result.connectionType()).isEqualTo("Failure");
+        assertThat(result.message()).contains("脚本执行失败").contains("bad script");
+    }
+
+    private static FilterScriptConfig config(String script) {
+        FilterScriptConfig config = new FilterScriptConfig();
+        config.setLanguage("javascript");
+        config.setScript(script);
+        return config;
+    }
+
+    private static RuleContext context(Map<String, Object> properties, Map<String, Object> enrichedData) {
+        RuleContext context = new RuleContext();
+        context.setDeviceKey("device-001");
+        context.setDeviceId(1001);
+        context.setDeviceName("温控器");
+        context.setMessageType(RuleContext.MessageType.PROPERTY);
+        context.getEnrichedData().putAll(enrichedData);
+
+        DecodeResult decodeResult = new DecodeResult();
+        properties.forEach((identifier, value) -> decodeResult.getDataList().add(new DeviceData(identifier, DataTypeEnum.DOUBLE, value)));
+        context.setDecodeResult(decodeResult);
+        return context;
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/service/ProtocolServiceScriptTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/service/ProtocolServiceScriptTest.java
@@ -1,0 +1,85 @@
+package com.github.dingdaoyi.service;
+
+import com.github.dingdaoyi.entity.Protocol;
+import com.github.dingdaoyi.entity.enu.ProtoType;
+import com.github.dingdaoyi.proto.model.DecodeResult;
+import com.github.dingdaoyi.proto.model.EncoderResult;
+import com.github.dingdaoyi.proto.model.ProtoMessageType;
+import com.github.dingdaoyi.service.impl.ProtocolServiceImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProtocolServiceScriptTest {
+
+    private final ProtocolService protocolService = new ProtocolServiceImpl();
+
+    @Test
+    void testDecodeRunsJavaScriptDraftWithoutPersistingProtocol() throws Exception {
+        Protocol protocol = javascriptProtocol("""
+                exports.decode = function(request) {
+                  const payload = JSON.parse(request.data);
+                  return {
+                    messageId: payload.mid,
+                    rawData: request.data,
+                    dataList: [
+                      { identifier: 'temperature', type: 'DOUBLE', value: payload.temperature }
+                    ]
+                  };
+                };
+                """);
+
+        DecodeResult result = protocolService.testDecode(
+                protocol,
+                "device-js-debug",
+                "product-js-debug",
+                ProtoMessageType.PROPERTY,
+                "{\"mid\": 2001, \"temperature\": 23.6}"
+        );
+
+        assertThat(result.getMessageId()).isEqualTo(2001);
+        assertThat(result.getRowData()).contains("temperature");
+        assertThat(result.getDataList()).hasSize(1);
+        assertThat(result.getDataList().getFirst().getIdentifier()).isEqualTo("temperature");
+        assertThat(result.getDataList().getFirst().getValue()).isEqualTo(23.6D);
+    }
+
+    @Test
+    void testEncodeRunsJavaScriptDraftWithoutPersistingProtocol() throws Exception {
+        Protocol protocol = javascriptProtocol("""
+                exports.encode = function(message) {
+                  return {
+                    messageId: 3002,
+                    message: JSON.stringify({ identifier: message.identifier, params: message.params }),
+                    needReply: true,
+                    metadata: { topic: '/device/' + message.deviceKey + '/command' }
+                  };
+                };
+                """);
+
+        EncoderResult result = protocolService.testEncode(
+                protocol,
+                "device-js-debug",
+                "product-js-debug",
+                "setPower",
+                Map.of("power", true)
+        );
+
+        assertThat(result.getMessageId()).isEqualTo(3002);
+        assertThat(new String(result.getMessage())).contains("setPower", "power");
+        assertThat(result.isNeedReply()).isTrue();
+        assertThat(result.getMetadata()).containsEntry("topic", "/device/device-js-debug/command");
+    }
+
+    private Protocol javascriptProtocol(String scriptContent) {
+        Protocol protocol = new Protocol();
+        protocol.setName("JS 调试协议");
+        protocol.setProtoKey("js-debug-draft");
+        protocol.setProtoType(ProtoType.JAVASCRIPT);
+        protocol.setScriptLang("javascript");
+        protocol.setScriptContent(scriptContent);
+        return protocol;
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/service/RuleChainDebugServiceTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/service/RuleChainDebugServiceTest.java
@@ -1,0 +1,156 @@
+package com.github.dingdaoyi.service;
+
+import com.github.dingdaoyi.controller.iot.dto.RuleChainDebugRequest;
+import com.github.dingdaoyi.entity.RuleChain;
+import com.github.dingdaoyi.entity.enu.RuleNodeType;
+import com.github.dingdaoyi.model.vo.RuleChainDebugResultVo;
+import com.github.dingdaoyi.proto.model.DataTypeEnum;
+import com.github.dingdaoyi.rule.RuleChainEngine;
+import com.github.dingdaoyi.rule.RuleContext;
+import com.github.dingdaoyi.rule.RuleNodeExecutor;
+import com.github.dingdaoyi.rule.config.FilterPropertyConfig;
+import com.github.dingdaoyi.rule.config.InputPropertyConfig;
+import com.github.dingdaoyi.service.impl.RuleChainServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RuleChainDebugServiceTest {
+
+    private RuleChainServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        RuleChainEngine engine = new RuleChainEngine();
+        ReflectionTestUtils.setField(engine, "executors", List.of(
+            new com.github.dingdaoyi.rule.node.InputPropertyNode(),
+            new com.github.dingdaoyi.rule.node.PropertyFilterNode()
+        ));
+        engine.init();
+
+        service = new RuleChainServiceImpl();
+        ReflectionTestUtils.setField(service, "ruleChainEngine", engine);
+    }
+
+    @Test
+    void debugExecutesDraftRuleChainAndReturnsRichTrace() {
+        RuleChainDebugRequest request = new RuleChainDebugRequest();
+        request.setRuleChain(ruleChain(
+            List.of(
+                inputNode("input", "属性输入"),
+                propertyFilterNode("filter", "温度过滤", "temperature", "GT", 30)
+            ),
+            List.of(connection("input", "filter", "Success"))
+        ));
+        request.setMessageType(RuleContext.MessageType.PROPERTY);
+        request.setDeviceKey("device-001");
+        request.setDeviceName("温控器");
+        request.setProperties(Map.of("temperature", 36.5));
+        request.setEnrichedData(Map.of("scenario", "uat"));
+
+        RuleChainDebugResultVo result = service.debug(request);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getRuleChainName()).isEqualTo("草稿规则链");
+        assertThat(result.getExecutedNodeCount()).isEqualTo(2);
+        assertThat(result.getDurationMs()).isGreaterThanOrEqualTo(0);
+        assertThat(result.getTraces()).hasSize(2);
+
+        RuleContext.ExecutionTrace inputTrace = result.getTraces().get(0);
+        assertThat(inputTrace.getNodeId()).isEqualTo("input");
+        assertThat(inputTrace.getNodeType()).isEqualTo("INPUT_PROPERTY");
+        assertThat(inputTrace.getStatus()).isEqualTo("SUCCESS");
+        assertThat(inputTrace.getInput()).containsEntry("messageType", "PROPERTY");
+        assertThat(inputTrace.getOutput()).containsEntry("connectionType", "Success");
+        assertThat(inputTrace.getDurationMs()).isGreaterThanOrEqualTo(0);
+
+        RuleContext.ExecutionTrace filterTrace = result.getTraces().get(1);
+        assertThat(filterTrace.getNodeId()).isEqualTo("filter");
+        assertThat(filterTrace.getNodeType()).isEqualTo("FILTER_PROPERTY");
+        assertThat(filterTrace.getConnectionType()).isEqualTo("True");
+        assertThat(filterTrace.getStatus()).isEqualTo("SUCCESS");
+        assertThat(filterTrace.getDetail()).contains("temperature=36.5");
+        assertThat(filterTrace.getOutput()).containsEntry("success", true);
+    }
+
+    @Test
+    void debugMarksFailureWhenNodeExecutorThrows() {
+        RuleChainEngine engine = new RuleChainEngine();
+        ReflectionTestUtils.setField(engine, "executors", List.of(new ThrowingExecutor()));
+        engine.init();
+        ReflectionTestUtils.setField(service, "ruleChainEngine", engine);
+
+        RuleChainDebugRequest request = new RuleChainDebugRequest();
+        request.setRuleChain(ruleChain(List.of(inputNode("input", "属性输入")), List.of()));
+        request.setMessageType(RuleContext.MessageType.PROPERTY);
+        request.setProperties(Map.of("temperature", 36.5));
+
+        RuleChainDebugResultVo result = service.debug(request);
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getTraces()).hasSize(1);
+        assertThat(result.getTraces().getFirst().getStatus()).isEqualTo("ERROR");
+        assertThat(result.getTraces().getFirst().getError()).isEqualTo("boom");
+    }
+
+    private static RuleChain ruleChain(List<RuleChain.RuleNode> nodes, List<RuleChain.RuleConnection> connections) {
+        RuleChain ruleChain = new RuleChain();
+        ruleChain.setId(100);
+        ruleChain.setName("草稿规则链");
+        ruleChain.setIsEnabled(true);
+        RuleChain.RuleChainConfiguration configuration = new RuleChain.RuleChainConfiguration();
+        configuration.setNodes(nodes);
+        configuration.setConnections(connections);
+        ruleChain.setConfiguration(configuration);
+        return ruleChain;
+    }
+
+    private static RuleChain.RuleNode inputNode(String id, String name) {
+        RuleChain.RuleNode node = node(id, RuleNodeType.INPUT_PROPERTY, name);
+        node.setConfig(new InputPropertyConfig());
+        return node;
+    }
+
+    private static RuleChain.RuleNode propertyFilterNode(String id, String name, String identifier, String operator, Object value) {
+        FilterPropertyConfig config = new FilterPropertyConfig();
+        config.setIdentifier(identifier);
+        config.setOperator(operator);
+        config.setValue(value);
+        RuleChain.RuleNode node = node(id, RuleNodeType.FILTER_PROPERTY, name);
+        node.setConfig(config);
+        return node;
+    }
+
+    private static RuleChain.RuleNode node(String id, RuleNodeType type, String name) {
+        RuleChain.RuleNode node = new RuleChain.RuleNode();
+        node.setId(id);
+        node.setType(type.name());
+        node.setName(name);
+        return node;
+    }
+
+    private static RuleChain.RuleConnection connection(String source, String target, String type) {
+        RuleChain.RuleConnection connection = new RuleChain.RuleConnection();
+        connection.setSource(source);
+        connection.setTarget(target);
+        connection.setType(type);
+        return connection;
+    }
+
+    private static class ThrowingExecutor implements RuleNodeExecutor {
+        @Override
+        public RuleNodeType getNodeType() {
+            return RuleNodeType.INPUT_PROPERTY;
+        }
+
+        @Override
+        public NodeResult execute(RuleContext context, com.github.dingdaoyi.rule.config.NodeConfig config) {
+            throw new IllegalStateException("boom");
+        }
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/service/RuleChainValidationServiceTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/service/RuleChainValidationServiceTest.java
@@ -1,0 +1,90 @@
+package com.github.dingdaoyi.service;
+
+import com.github.dingdaoyi.entity.RuleChain;
+import com.github.dingdaoyi.entity.enu.RuleNodeType;
+import com.github.dingdaoyi.model.vo.RuleChainValidationResultVo;
+import com.github.dingdaoyi.rule.config.InputPropertyConfig;
+import com.github.dingdaoyi.rule.config.OutputMessageConfig;
+import com.github.dingdaoyi.service.impl.RuleChainServiceImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RuleChainValidationServiceTest {
+
+    private final RuleChainServiceImpl service = new RuleChainServiceImpl();
+
+    @Test
+    void validateReportsInvalidConnectionAndUnreachableNode() {
+        RuleChain ruleChain = ruleChain(
+            List.of(
+                node("input", RuleNodeType.INPUT_PROPERTY, "属性输入", new InputPropertyConfig()),
+                node("output", RuleNodeType.OUTPUT_MESSAGE, "消息输出", new OutputMessageConfig()),
+                node("orphan", RuleNodeType.OUTPUT_MESSAGE, "孤立输出", new OutputMessageConfig())
+            ),
+            List.of(
+                connection("output", "input", "Success")
+            )
+        );
+
+        RuleChainValidationResultVo result = service.validateDraft(ruleChain);
+
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getErrors()).anySatisfy(error -> {
+            assertThat(error.getCode()).isEqualTo("INVALID_CONNECTION");
+            assertThat(error.getMessage()).contains("输出节点是终端节点");
+        });
+        assertThat(result.getWarnings()).anySatisfy(warning -> {
+            assertThat(warning.getCode()).isEqualTo("UNREACHABLE_NODE");
+            assertThat(warning.getNodeId()).isEqualTo("orphan");
+        });
+        assertThat(result.getReachableNodeIds()).containsExactly("input");
+    }
+
+    @Test
+    void validatePassesSimpleInputToOutputChain() {
+        RuleChain ruleChain = ruleChain(
+            List.of(
+                node("input", RuleNodeType.INPUT_PROPERTY, "属性输入", new InputPropertyConfig()),
+                node("output", RuleNodeType.OUTPUT_MESSAGE, "消息输出", new OutputMessageConfig())
+            ),
+            List.of(connection("input", "output", "Success"))
+        );
+
+        RuleChainValidationResultVo result = service.validateDraft(ruleChain);
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getReachableNodeIds()).containsExactlyInAnyOrder("input", "output");
+    }
+
+    private static RuleChain ruleChain(List<RuleChain.RuleNode> nodes, List<RuleChain.RuleConnection> connections) {
+        RuleChain ruleChain = new RuleChain();
+        ruleChain.setName("草稿规则链");
+        ruleChain.setIsEnabled(true);
+        RuleChain.RuleChainConfiguration configuration = new RuleChain.RuleChainConfiguration();
+        configuration.setNodes(nodes);
+        configuration.setConnections(connections);
+        ruleChain.setConfiguration(configuration);
+        return ruleChain;
+    }
+
+    private static RuleChain.RuleNode node(String id, RuleNodeType type, String name, com.github.dingdaoyi.rule.config.NodeConfig config) {
+        RuleChain.RuleNode node = new RuleChain.RuleNode();
+        node.setId(id);
+        node.setType(type.name());
+        node.setName(name);
+        node.setConfig(config);
+        return node;
+    }
+
+    private static RuleChain.RuleConnection connection(String source, String target, String type) {
+        RuleChain.RuleConnection connection = new RuleChain.RuleConnection();
+        connection.setSource(source);
+        connection.setTarget(target);
+        connection.setType(type);
+        return connection;
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/service/push/HttpPushDeliveryServiceTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/service/push/HttpPushDeliveryServiceTest.java
@@ -1,0 +1,100 @@
+package com.github.dingdaoyi.service.push;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dingdaoyi.entity.PushConfig;
+import com.github.dingdaoyi.entity.enu.PushConfigType;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class HttpPushDeliveryServiceTest {
+
+    @Test
+    void deliverHttpAddsStandardHmacWebhookHeaders() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        HttpPushDeliveryService service = service(restTemplate, true);
+        PushConfig config = httpConfig("https://example.com/webhook");
+        config.setHttpSignEnabled(true);
+        config.setHttpSignSecret("demo-secret");
+
+        String body = "{\"temperature\":36.5}";
+        String expectedSignature = new PushWebhookSigner().sign("demo-secret", "1710000000000", body);
+        server.expect(requestTo("https://example.com/webhook"))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(header("X-Simple-IoT-Timestamp", "1710000000000"))
+            .andExpect(header("X-Simple-IoT-Signature", expectedSignature))
+            .andExpect(header("X-Simple-IoT-Signature-Method", "HMAC-SHA256"))
+            .andExpect(header("X-Simple-IoT-Event", "telemetry.property"))
+            .andExpect(content().json(body))
+            .andRespond(withSuccess("{\"ok\":true}", MediaType.APPLICATION_JSON));
+
+        PushDeliveryResult result = service.deliverHttp(config, body, "telemetry.property");
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getStatusCode()).isEqualTo(200);
+        assertThat(result.getMessage()).contains("HTTP推送成功");
+        server.verify();
+    }
+
+    @Test
+    void deliverHttpBlocksPrivateNetworkEndpointWhenGuardIsDisabled() {
+        HttpPushDeliveryService service = service(new RestTemplate(), false);
+        PushConfig config = httpConfig("http://127.0.0.1:8080/webhook");
+
+        PushDeliveryResult result = service.deliverHttp(config, "{}", "telemetry.property");
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getMessage()).contains("不允许推送到内网或本机地址");
+    }
+
+    @Test
+    void deliverHttpAllowsPrivateNetworkEndpointWhenGuardIsEnabledForDemoOrTests() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        HttpPushDeliveryService service = service(restTemplate, true);
+        PushConfig config = httpConfig("http://127.0.0.1:8080/webhook");
+
+        server.expect(requestTo("http://127.0.0.1:8080/webhook"))
+            .andExpect(method(HttpMethod.POST))
+            .andRespond(withSuccess("ok", MediaType.TEXT_PLAIN));
+
+        PushDeliveryResult result = service.deliverHttp(config, Map.of("ok", true), "push.test");
+
+        assertThat(result.isSuccess()).isTrue();
+        server.verify();
+    }
+
+    private HttpPushDeliveryService service(RestTemplate restTemplate, boolean allowPrivateEndpoints) {
+        return new HttpPushDeliveryService(
+            restTemplate,
+            new ObjectMapper(),
+            new PushWebhookSigner(),
+            new PushEndpointGuard(allowPrivateEndpoints),
+            Clock.fixed(Instant.ofEpochMilli(1710000000000L), ZoneOffset.UTC)
+        );
+    }
+
+    private PushConfig httpConfig(String url) {
+        PushConfig config = new PushConfig();
+        config.setId(1);
+        config.setName("Webhook");
+        config.setType(PushConfigType.HTTP);
+        config.setIsEnabled(true);
+        config.setHttpUrl(url);
+        config.setHttpMethod("POST");
+        config.setHttpTimeout(5000);
+        return config;
+    }
+}

--- a/iot-server/src/test/java/com/github/dingdaoyi/service/push/PushWebhookSignerTest.java
+++ b/iot-server/src/test/java/com/github/dingdaoyi/service/push/PushWebhookSignerTest.java
@@ -1,0 +1,27 @@
+package com.github.dingdaoyi.service.push;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PushWebhookSignerTest {
+
+    @Test
+    void signBuildsStableHmacSha256HexFromTimestampAndBody() {
+        PushWebhookSigner signer = new PushWebhookSigner();
+
+        String signature = signer.sign("demo-secret", "1710000000000", "{\"temperature\":36.5}");
+
+        assertThat(signature).isEqualTo("bb1f7c40d561d7d581154010dbddacbc19ce32ec4c578532ea56a60fd93ada4d");
+    }
+
+    @Test
+    void signTreatsNullBodyAsEmptyString() {
+        PushWebhookSigner signer = new PushWebhookSigner();
+
+        String nullBodySignature = signer.sign("demo-secret", "1710000000000", null);
+        String emptyBodySignature = signer.sign("demo-secret", "1710000000000", "");
+
+        assertThat(nullBodySignature).isEqualTo(emptyBodySignature);
+    }
+}

--- a/iot-web/src/api/index.js
+++ b/iot-web/src/api/index.js
@@ -761,6 +761,17 @@ export function ruleChainDebugApi(data) {
 }
 
 /**
+ * 校验规则链草稿
+ */
+export function ruleChainValidateApi(data) {
+  return request({
+    url: '/rule-chain/validate',
+    method: 'post',
+    data,
+  })
+}
+
+/**
  * 获取模板变量列表
  * @param {number} productId - 产品ID，用于获取物模型属性
  */

--- a/iot-web/src/api/index.js
+++ b/iot-web/src/api/index.js
@@ -323,6 +323,32 @@ export function protocolSetStatusApi(id, enable) {
 }
 
 /**
+ * 测试脚本协议解码
+ * @param data 协议草稿和测试报文
+ * @returns {Promise} API 响应
+ */
+export function protocolTestDecodeApi(data) {
+  return request({
+    url: '/protocol/test/decode',
+    method: 'post',
+    data,
+  })
+}
+
+/**
+ * 测试脚本协议编码
+ * @param data 协议草稿和测试命令
+ * @returns {Promise} API 响应
+ */
+export function protocolTestEncodeApi(data) {
+  return request({
+    url: '/protocol/test/encode',
+    method: 'post',
+    data,
+  })
+}
+
+/**
  * 图标列表
  * @param params
  * @returns {Promise} API 响应

--- a/iot-web/src/api/index.js
+++ b/iot-web/src/api/index.js
@@ -739,6 +739,17 @@ export function ruleChainNodeTypesApi() {
 }
 
 /**
+ * 调试执行规则链草稿
+ */
+export function ruleChainDebugApi(data) {
+  return request({
+    url: '/rule-chain/debug',
+    method: 'post',
+    data,
+  })
+}
+
+/**
  * 获取模板变量列表
  * @param {number} productId - 产品ID，用于获取物模型属性
  */

--- a/iot-web/src/api/index.js
+++ b/iot-web/src/api/index.js
@@ -649,6 +649,17 @@ export function pushConfigListApi(params) {
 }
 
 /**
+ * 测试推送配置
+ */
+export function pushConfigTestApi(id, data) {
+  return request({
+    url: `/push-config/${id}/test`,
+    method: 'post',
+    data,
+  })
+}
+
+/**
  * 调用设备服务
  * @param deviceKey 设备编号
  * @param identifier 服务标识符

--- a/iot-web/src/views/protocol/widget/editDia.vue
+++ b/iot-web/src/views/protocol/widget/editDia.vue
@@ -1,6 +1,7 @@
 <script lang="jsx" setup>
+import { ElMessage } from 'element-plus'
 import { computed, ref, watch } from 'vue'
-import { protocolAddApi, protocolEditApi } from '@/api'
+import { protocolAddApi, protocolEditApi, protocolTestDecodeApi, protocolTestEncodeApi } from '@/api'
 import { useForm } from '@/composables/useForm.js'
 import CodeEditor from './CodeEditor.vue'
 
@@ -143,6 +144,23 @@ const { form, onSubmit: handleSubmit, editRef, loading } = useForm({
 })
 
 const isScriptType = computed(() => form.value.protoType === 3)
+const testDialogVisible = ref(false)
+const testMode = ref('decode')
+const testLoading = ref(false)
+const testResult = ref(null)
+const testForm = ref({
+  deviceKey: 'debug-device-001',
+  productKey: 'debug-product',
+  messageType: 'PROPERTY',
+  data: '{"temperature": 25.5, "humidity": 60}',
+  identifier: 'setPower',
+  paramsText: `{
+  "power": "on"
+}`,
+})
+
+const testDialogTitle = computed(() => testMode.value === 'decode' ? '测试解码' : '测试编码')
+const formattedTestResult = computed(() => testResult.value ? JSON.stringify(testResult.value, null, 2) : '')
 
 // 默认脚本模板
 const scriptTemplates = {
@@ -300,6 +318,76 @@ function onCancel() {
   emits('update:modelValue', false)
 }
 
+function openTestDialog(mode) {
+  if (!isScriptType.value) {
+    ElMessage.warning('仅脚本协议支持在线调试')
+    return
+  }
+  if (!form.value.scriptContent) {
+    ElMessage.warning('请先填写脚本内容')
+    return
+  }
+  testMode.value = mode
+  testResult.value = null
+  testDialogVisible.value = true
+}
+
+function buildProtocolDraft() {
+  return {
+    ...form.value,
+    protoType: 3,
+    scriptLang: form.value.scriptLang || 'javascript',
+    protoKey: form.value.protoKey || 'debug-script',
+    name: form.value.name || '脚本调试协议',
+  }
+}
+
+async function runProtocolTest() {
+  try {
+    testLoading.value = true
+    testResult.value = null
+    if (testMode.value === 'decode') {
+      const { data } = await protocolTestDecodeApi({
+        protocol: buildProtocolDraft(),
+        deviceKey: testForm.value.deviceKey,
+        productKey: testForm.value.productKey,
+        messageType: testForm.value.messageType,
+        data: testForm.value.data,
+      })
+      testResult.value = data
+      ElMessage.success('解码测试成功')
+      return
+    }
+
+    let params = {}
+    if (testForm.value.paramsText?.trim()) {
+      params = JSON.parse(testForm.value.paramsText)
+    }
+    const { data } = await protocolTestEncodeApi({
+      protocol: buildProtocolDraft(),
+      deviceKey: testForm.value.deviceKey,
+      productKey: testForm.value.productKey,
+      identifier: testForm.value.identifier,
+      params,
+    })
+    testResult.value = data
+    ElMessage.success('编码测试成功')
+  }
+  catch (error) {
+    testResult.value = {
+      success: false,
+      message: error?.msg || error?.message || '测试失败',
+      detail: error,
+    }
+    if (error instanceof SyntaxError) {
+      ElMessage.error('编码参数不是合法 JSON')
+    }
+  }
+  finally {
+    testLoading.value = false
+  }
+}
+
 watch(() => props.datas, (val) => {
   if (val) {
     form.value = { ...val }
@@ -444,6 +532,12 @@ watch(() => form.value.scriptLang, () => {
                 📄 重置模板
               </el-button>
               <!-- API 文档提示 -->
+              <el-button size="small" type="success" plain @click="openTestDialog('decode')">
+                测试解码
+              </el-button>
+              <el-button size="small" type="warning" plain @click="openTestDialog('encode')">
+                测试编码
+              </el-button>
               <el-popover
                 placement="bottom"
                 :width="480"
@@ -493,6 +587,75 @@ watch(() => form.value.scriptLang, () => {
       </el-button>
     </template>
   </el-dialog>
+
+  <el-dialog
+    v-model="testDialogVisible"
+    :title="testDialogTitle"
+    width="720px"
+  >
+    <el-form label-width="110px" :model="testForm">
+      <el-row :gutter="16">
+        <el-col :span="12">
+          <el-form-item label="设备Key">
+            <el-input v-model="testForm.deviceKey" clearable />
+          </el-form-item>
+        </el-col>
+        <el-col :span="12">
+          <el-form-item label="产品Key">
+            <el-input v-model="testForm.productKey" clearable />
+          </el-form-item>
+        </el-col>
+      </el-row>
+
+      <template v-if="testMode === 'decode'">
+        <el-form-item label="消息类型">
+          <el-select v-model="testForm.messageType" style="width: 100%">
+            <el-option label="属性上报 PROPERTY" value="PROPERTY" />
+            <el-option label="事件上报 EVENT" value="EVENT" />
+            <el-option label="服务响应 SERVICE_RES" value="SERVICE_RES" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="原始报文">
+          <el-input
+            v-model="testForm.data"
+            type="textarea"
+            :rows="5"
+            placeholder="请输入设备原始报文，例如 JSON 字符串"
+          />
+        </el-form-item>
+      </template>
+
+      <template v-else>
+        <el-form-item label="功能标识符">
+          <el-input v-model="testForm.identifier" clearable placeholder="例如 setPower" />
+        </el-form-item>
+        <el-form-item label="下行参数">
+          <el-input
+            v-model="testForm.paramsText"
+            type="textarea"
+            :rows="6"
+            placeholder="请输入 JSON 对象"
+          />
+        </el-form-item>
+      </template>
+    </el-form>
+
+    <div v-if="testResult" class="test-result">
+      <div class="test-result-title">
+        执行结果
+      </div>
+      <pre>{{ formattedTestResult }}</pre>
+    </div>
+
+    <template #footer>
+      <el-button @click="testDialogVisible = false">
+        关闭
+      </el-button>
+      <el-button type="primary" :loading="testLoading" @click="runProtocolTest">
+        运行测试
+      </el-button>
+    </template>
+  </el-dialog>
 </template>
 
 <style lang="scss" scoped>
@@ -515,6 +678,35 @@ watch(() => form.value.scriptLang, () => {
       align-items: center;
       gap: var(--space-sm);
     }
+  }
+}
+
+.test-result {
+  margin-top: var(--space-md);
+  border: 1px solid var(--iot-color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+
+  .test-result-title {
+    padding: var(--space-sm) var(--space-md);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--iot-color-text-primary);
+    background: var(--iot-glass-bg);
+    border-bottom: 1px solid var(--iot-color-border);
+  }
+
+  pre {
+    margin: 0;
+    padding: var(--space-md);
+    max-height: 320px;
+    overflow: auto;
+    font-size: 12px;
+    line-height: 1.6;
+    color: #d4d4d4;
+    background: #1e1e1e;
+    white-space: pre-wrap;
+    word-break: break-all;
   }
 }
 

--- a/iot-web/src/views/push-config/index.vue
+++ b/iot-web/src/views/push-config/index.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { Delete, Edit, RefreshRight } from '@element-plus/icons-vue'
-import { onMounted } from 'vue'
-import { pushConfigDeleteApi, pushConfigPageApi } from '@/api/index.js'
+import { Delete, Edit, Promotion, RefreshRight } from '@element-plus/icons-vue'
+import { ElMessage } from 'element-plus'
+import { onMounted, ref } from 'vue'
+import { pushConfigDeleteApi, pushConfigPageApi, pushConfigTestApi } from '@/api/index.js'
 import IotTable from '@/components/IotTable.vue'
 import { useTable } from '@/composables/useTable.js'
 import EditDia from '@/views/push-config/widget/editDia.vue'
@@ -53,7 +54,7 @@ const column = [
   {
     prop: 'cz',
     slot: 'cz',
-    width: 150,
+    width: 210,
     label: '操作',
     fixed: 'right',
   },
@@ -84,6 +85,63 @@ const {
 
 function closeEdite() {
   updatePage()
+}
+
+const testDialogVisible = ref(false)
+const testLoading = ref(false)
+const testTarget = ref(null)
+const testForm = ref({
+  eventType: 'push.test',
+  payload: '{\n  "temperature": 36.5,\n  "humidity": 60\n}',
+})
+const testResult = ref(null)
+
+function openTestDialog(row) {
+  testTarget.value = row
+  testResult.value = null
+  testForm.value = {
+    eventType: 'push.test',
+    payload: '{\n  "temperature": 36.5,\n  "humidity": 60\n}',
+  }
+  testDialogVisible.value = true
+}
+
+function parseTestPayload() {
+  const payload = testForm.value.payload
+  if (!payload || !payload.trim()) {
+    return {}
+  }
+  try {
+    return JSON.parse(payload)
+  }
+  catch {
+    return payload
+  }
+}
+
+async function runTestPush() {
+  if (!testTarget.value?.id) {
+    return
+  }
+  testLoading.value = true
+  testResult.value = null
+  try {
+    const res = await pushConfigTestApi(testTarget.value.id, {
+      eventType: testForm.value.eventType || 'push.test',
+      payload: parseTestPayload(),
+    })
+    const data = res?.data || res
+    testResult.value = data
+    if (data?.success) {
+      ElMessage.success('测试推送成功')
+    }
+    else {
+      ElMessage.warning(data?.message || '测试推送失败')
+    }
+  }
+  finally {
+    testLoading.value = false
+  }
 }
 
 onMounted(() => {
@@ -180,6 +238,9 @@ onMounted(() => {
           </el-tag>
         </template>
         <template #cz="{ row }">
+          <el-button type="primary" link :icon="Promotion" @click="openTestDialog(row)">
+            测试
+          </el-button>
           <el-button type="primary" link :icon="Edit" @click="onEdit(row)">
             编辑
           </el-button>
@@ -189,6 +250,53 @@ onMounted(() => {
         </template>
       </IotTable>
     </div>
+
+    <!-- 测试推送对话框 -->
+    <el-dialog v-model="testDialogVisible" title="测试推送配置" width="640px">
+      <el-form label-width="90px">
+        <el-form-item label="配置名称">
+          <el-input :model-value="testTarget?.name || '-'" disabled />
+        </el-form-item>
+        <el-form-item label="事件类型">
+          <el-input v-model="testForm.eventType" placeholder="push.test" />
+        </el-form-item>
+        <el-form-item label="测试负载">
+          <el-input
+            v-model="testForm.payload"
+            type="textarea"
+            :rows="8"
+            placeholder="请输入 JSON 或普通文本"
+          />
+        </el-form-item>
+        <el-alert
+          v-if="testTarget?.httpSignEnabled"
+          type="info"
+          show-icon
+          :closable="false"
+          title="该配置已启用 HMAC 签名，测试请求会自动携带 X-Simple-IoT-Timestamp / Signature / Event 请求头。"
+        />
+        <el-alert
+          v-if="testResult"
+          class="test-result"
+          :type="testResult.success ? 'success' : 'error'"
+          show-icon
+          :closable="false"
+          :title="testResult.message || (testResult.success ? '测试推送成功' : '测试推送失败')"
+        >
+          <template v-if="testResult.responseBody" #default>
+            <pre>{{ testResult.responseBody }}</pre>
+          </template>
+        </el-alert>
+      </el-form>
+      <template #footer>
+        <el-button @click="testDialogVisible = false">
+          关闭
+        </el-button>
+        <el-button type="primary" :loading="testLoading" @click="runTestPush">
+          发送测试
+        </el-button>
+      </template>
+    </el-dialog>
 
     <!-- 编辑对话框 -->
     <EditDia
@@ -314,6 +422,21 @@ onMounted(() => {
 
   .page-title {
     font-size: 20px !important;
+  }
+}
+
+.test-result {
+  margin-top: var(--space-md);
+
+  pre {
+    margin: 8px 0 0;
+    padding: 8px;
+    max-height: 160px;
+    overflow: auto;
+    background: rgba(15, 23, 42, 0.06);
+    border-radius: var(--radius-sm);
+    white-space: pre-wrap;
+    word-break: break-word;
   }
 }
 </style>

--- a/iot-web/src/views/push-config/widget/editDia.vue
+++ b/iot-web/src/views/push-config/widget/editDia.vue
@@ -96,6 +96,8 @@ function resetHttpFields() {
   form.value.httpUrl = ''
   form.value.httpMethod = 'POST'
   form.value.httpTimeout = 5000
+  form.value.httpSignEnabled = false
+  form.value.httpSignSecret = ''
   httpHeaders.value = []
 }
 
@@ -141,6 +143,8 @@ watch(() => props.datas, (val) => {
       httpMethod: 'POST',
       httpHeaders: [],
       httpTimeout: 5000,
+      httpSignEnabled: false,
+      httpSignSecret: '',
       // MQTT
       mqttBroker: '',
       mqttUsername: '',
@@ -258,6 +262,23 @@ watch(() => props.datas, (val) => {
           <div class="form-tip">
             单位：毫秒
           </div>
+        </el-form-item>
+
+        <el-form-item label="HMAC签名" prop="httpSignEnabled">
+          <el-switch v-model="form.httpSignEnabled" />
+          <div class="form-tip">
+            开启后推送会自动携带 X-Simple-IoT-Timestamp / Signature / Event 请求头
+          </div>
+        </el-form-item>
+
+        <el-form-item v-if="form.httpSignEnabled" label="签名密钥" prop="httpSignSecret">
+          <el-input
+            v-model="form.httpSignSecret"
+            type="password"
+            show-password
+            clearable
+            placeholder="请输入 Webhook 签名密钥"
+          />
         </el-form-item>
       </template>
 

--- a/iot-web/src/views/rule-chain/editor/index.vue
+++ b/iot-web/src/views/rule-chain/editor/index.vue
@@ -15,6 +15,7 @@ import {
   ruleChainDetailApi,
   ruleChainNodeTypesApi,
   ruleChainUpdateApi,
+  ruleChainValidateApi,
 } from '@/api/index.js'
 import NodeConfigPanel from './NodeConfigPanel.vue'
 
@@ -366,6 +367,27 @@ const debugTraceMap = computed(() => {
   })
   return map
 })
+
+const debugExecutedConnectionSet = computed(() => {
+  const set = new Set()
+  ;(debugResult.value?.executedConnections || []).forEach((conn) => {
+    set.add(`${conn.source}->${conn.target}:${getConnectionType(conn)}`)
+  })
+  return set
+})
+
+const validationIssues = computed(() => [
+  ...(debugResult.value?.validation?.errors || []),
+  ...(debugResult.value?.validation?.warnings || []),
+])
+
+function isDebugConnectionExecuted(line) {
+  return debugExecutedConnectionSet.value.has(`${line.sourceNode}->${line.targetNode}:${line.connectionType}`)
+}
+
+function getValidationIssueType(issue) {
+  return (debugResult.value?.validation?.errors || []).includes(issue) ? 'danger' : 'warning'
+}
 
 // 加载节点类型
 async function loadNodeTypes() {
@@ -905,11 +927,44 @@ async function handleDebugRun() {
     }
     const { data } = await ruleChainDebugApi(payload)
     debugResult.value = normalizeApiData(data)
-    ElMessage.success('调试执行完成')
+    ElMessage.success('调试执行完成，已在画布高亮执行路径')
   }
   catch (e) {
     ElMessage.error(e.message || '调试执行失败')
     console.error('调试执行失败', e)
+  }
+  finally {
+    debugRunning.value = false
+  }
+}
+
+async function validateRuleChainDraft() {
+  const { data } = await ruleChainValidateApi(buildRuleChainDraft())
+  return normalizeApiData(data)
+}
+
+async function handleValidateDraft() {
+  debugRunning.value = true
+  try {
+    const validation = await validateRuleChainDraft()
+    debugResult.value = {
+      success: validation.valid,
+      executedNodeCount: 0,
+      durationMs: 0,
+      traces: [],
+      executedConnections: [],
+      validation,
+    }
+    if (validation.valid) {
+      ElMessage.success('规则链结构校验通过')
+    }
+    else {
+      ElMessage.warning(`规则链校验发现 ${validation.errors?.length || 0} 个错误`)
+    }
+  }
+  catch (e) {
+    ElMessage.error(e.message || '规则链校验失败')
+    console.error('规则链校验失败', e)
   }
   finally {
     debugRunning.value = false
@@ -1083,13 +1138,19 @@ onMounted(async () => {
             <path
               :d="generateBezierPath(line.source.x, line.source.y, line.target.x, line.target.y)"
               class="connection-line"
-              :class="`connection-${(line.connectionType || 'Success').toLowerCase()}`"
+              :class="[
+                `connection-${(line.connectionType || 'Success').toLowerCase()}`,
+                { 'debug-executed': isDebugConnectionExecuted(line) },
+              ]"
             />
             <!-- 箭头 -->
             <polygon
               :points="`${line.target.x - 8},${line.target.y - 5} ${line.target.x},${line.target.y} ${line.target.x - 8},${line.target.y + 5}`"
               class="connection-arrow"
-              :class="`connection-${(line.connectionType || 'Success').toLowerCase()}`"
+              :class="[
+                `connection-${(line.connectionType || 'Success').toLowerCase()}`,
+                { 'debug-executed': isDebugConnectionExecuted(line) },
+              ]"
             />
             <!-- 删除提示（hover时显示） -->
             <circle
@@ -1249,9 +1310,31 @@ onMounted(async () => {
                 {{ debugResult.success ? '成功' : '失败' }} · {{ debugResult.executedNodeCount || 0 }} 个节点 · {{ debugResult.durationMs || 0 }}ms
               </span>
             </div>
-            <el-button type="primary" :loading="debugRunning" @click="handleDebugRun">
-              运行调试
-            </el-button>
+            <div class="debug-actions">
+              <el-button :loading="debugRunning" @click="handleValidateDraft">
+                校验结构
+              </el-button>
+              <el-button type="primary" :loading="debugRunning" @click="handleDebugRun">
+                运行调试
+              </el-button>
+            </div>
+          </div>
+
+          <div v-if="validationIssues.length" class="validation-issues">
+            <el-alert
+              v-for="issue in validationIssues"
+              :key="`${issue.code}-${issue.nodeId || issue.connectionId || issue.message}`"
+              :type="getValidationIssueType(issue)"
+              :closable="false"
+              show-icon
+            >
+              <template #title>
+                {{ issue.message }}
+                <span class="issue-meta">
+                  {{ issue.nodeId || '' }} {{ issue.connectionId || '' }}
+                </span>
+              </template>
+            </el-alert>
           </div>
 
           <el-empty v-if="!debugResult" description="运行后展示节点执行轨迹" />
@@ -1486,6 +1569,13 @@ onMounted(async () => {
         opacity: 0.7;
         pointer-events: none;
       }
+
+      &.debug-executed {
+        stroke-width: 4;
+        stroke-dasharray: 8, 4;
+        filter: drop-shadow(0 0 6px rgba(16, 185, 129, 0.75));
+        animation: executedFlow 1.2s linear infinite;
+      }
     }
 
     // hover 时连接线变粗
@@ -1506,6 +1596,10 @@ onMounted(async () => {
       }
       &.connection-success {
         fill: var(--iot-color-primary);
+      }
+
+      &.debug-executed {
+        filter: drop-shadow(0 0 6px rgba(16, 185, 129, 0.75));
       }
     }
     // 删除提示（hover 时显示）
@@ -1754,6 +1848,25 @@ onMounted(async () => {
     margin-bottom: var(--space-md);
   }
 
+  .debug-actions {
+    display: flex;
+    gap: var(--space-sm);
+  }
+
+  .validation-issues {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-md);
+
+    .issue-meta {
+      margin-left: var(--space-sm);
+      color: var(--iot-color-text-muted);
+      font-size: 12px;
+      font-weight: 400;
+    }
+  }
+
   .debug-summary {
     margin-left: var(--space-sm);
     color: var(--iot-color-text-muted);
@@ -1895,6 +2008,15 @@ onMounted(async () => {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@keyframes executedFlow {
+  from {
+    stroke-dashoffset: 0;
+  }
+  to {
+    stroke-dashoffset: -24;
   }
 }
 </style>

--- a/iot-web/src/views/rule-chain/editor/index.vue
+++ b/iot-web/src/views/rule-chain/editor/index.vue
@@ -11,6 +11,7 @@ import {
   productTypeListApi,
   pushConfigListApi,
   ruleChainAddApi,
+  ruleChainDebugApi,
   ruleChainDetailApi,
   ruleChainNodeTypesApi,
   ruleChainUpdateApi,
@@ -63,6 +64,21 @@ const selectedNode = ref(null)
 
 // 保存加载状态
 const saving = ref(false)
+
+// 规则链调试状态
+const debugDialogVisible = ref(false)
+const debugRunning = ref(false)
+const debugResult = ref(null)
+const debugForm = ref({
+  deviceKey: 'demo-device-001',
+  deviceId: null,
+  deviceName: '演示设备',
+  messageType: 'PROPERTY',
+  propertiesJson: '{\n  "temperature": 36.5,\n  "humidity": 62\n}',
+  eventIdentifier: '',
+  eventParamsJson: '{}',
+  enrichedDataJson: '{}',
+})
 
 // 画布引用
 const canvasRef = ref(null)
@@ -341,6 +357,14 @@ const connectionLines = computed(() => {
       connectionType: connType,
     }
   }).filter(Boolean)
+})
+
+const debugTraceMap = computed(() => {
+  const map = {}
+  ;(debugResult.value?.traces || []).forEach((trace, index) => {
+    map[trace.nodeId] = { ...trace, index: index + 1 }
+  })
+  return map
 })
 
 // 加载节点类型
@@ -814,27 +838,89 @@ function generateBezierPath(x1, y1, x2, y2) {
   const cpOffset = Math.min(Math.abs(x2 - x1) * 0.5, 100)
   return `M ${x1} ${y1} C ${x1 + cpOffset} ${y1}, ${x2 - cpOffset} ${y2}, ${x2} ${y2}`
 }
+
+function buildRuleChainDraft() {
+  const configuration = {
+    nodes: ruleChain.value.configuration.nodes.map(node => ({
+      ...node,
+      config: node.config ? { ...node.config, nodeType: node.type } : null,
+    })),
+    connections: ruleChain.value.configuration.connections,
+  }
+
+  return {
+    ...ruleChain.value,
+    configuration,
+    sourceId: ruleChain.value.sourceType === 'PRODUCT'
+      ? ruleChain.value.productId
+      : ruleChain.value.sourceId,
+  }
+}
+
+function parseJsonField(value, fieldName) {
+  if (!value || !value.trim())
+    return {}
+  try {
+    return JSON.parse(value)
+  }
+  catch (e) {
+    throw new Error(`${fieldName} 不是合法 JSON: ${e.message}`)
+  }
+}
+
+function formatJson(value) {
+  return JSON.stringify(value ?? {}, null, 2)
+}
+
+function getTraceStatusType(status) {
+  if (status === 'SUCCESS')
+    return 'success'
+  if (status === 'FAILED' || status === 'ERROR')
+    return 'danger'
+  return 'warning'
+}
+
+function openDebugDialog() {
+  debugDialogVisible.value = true
+}
+
+async function handleDebugRun() {
+  if (ruleChain.value.configuration.nodes.length === 0) {
+    ElMessage.warning('请先添加规则节点')
+    return
+  }
+
+  debugRunning.value = true
+  try {
+    const payload = {
+      ruleChain: buildRuleChainDraft(),
+      deviceKey: debugForm.value.deviceKey,
+      deviceId: debugForm.value.deviceId,
+      deviceName: debugForm.value.deviceName,
+      messageType: debugForm.value.messageType,
+      properties: parseJsonField(debugForm.value.propertiesJson, '属性数据'),
+      eventIdentifier: debugForm.value.eventIdentifier || null,
+      eventParams: parseJsonField(debugForm.value.eventParamsJson, '事件参数'),
+      enrichedData: parseJsonField(debugForm.value.enrichedDataJson, '扩展变量'),
+    }
+    const { data } = await ruleChainDebugApi(payload)
+    debugResult.value = normalizeApiData(data)
+    ElMessage.success('调试执行完成')
+  }
+  catch (e) {
+    ElMessage.error(e.message || '调试执行失败')
+    console.error('调试执行失败', e)
+  }
+  finally {
+    debugRunning.value = false
+  }
+}
+
 // 保存
 async function handleSave() {
   saving.value = true
   try {
-    // 构建提交数据 - 为每个节点的 config 添加 nodeType 以支持后端多态反序列化
-    const configuration = {
-      nodes: ruleChain.value.configuration.nodes.map(node => ({
-        ...node,
-        config: node.config ? { ...node.config, nodeType: node.type } : null,
-      })),
-      connections: ruleChain.value.configuration.connections,
-    }
-
-    const submitData = {
-      ...ruleChain.value,
-      configuration,
-      // 如果sourceType是PRODUCT,sourceId就是productId
-      sourceId: ruleChain.value.sourceType === 'PRODUCT'
-        ? ruleChain.value.productId
-        : ruleChain.value.sourceId,
-    }
+    const submitData = buildRuleChainDraft()
     if (isEdit.value) {
       await ruleChainUpdateApi(submitData)
     }
@@ -876,6 +962,9 @@ onMounted(async () => {
         <span class="title">{{ isEdit ? '编辑规则引擎' : '新建规则引擎' }}</span>
       </div>
       <div class="header-right">
+        <el-button :loading="debugRunning" @click="openDebugDialog">
+          调试运行
+        </el-button>
         <el-button type="primary" :loading="saving" @click="handleSave">
           保存
         </el-button>
@@ -1044,6 +1133,8 @@ onMounted(async () => {
             'selected': selectedNode?.id === node.id,
             'is-input': isInputNode(node.type),
             'is-filter': isFilterNode(node.type),
+            'debug-success': debugTraceMap[node.id]?.status === 'SUCCESS',
+            'debug-failed': ['FAILED', 'ERROR'].includes(debugTraceMap[node.id]?.status),
           }"
           :style="{ 'left': `${node.x}px`, 'top': `${node.y}px`, '--node-color': node.color }"
           @click="selectedNode = selectedNode?.id === node.id ? null : node"
@@ -1065,6 +1156,9 @@ onMounted(async () => {
           <div class="node-body">
             <div class="node-type">
               {{ node.type }}
+            </div>
+            <div v-if="debugTraceMap[node.id]" class="node-debug-badge">
+              #{{ debugTraceMap[node.id].index }} · {{ debugTraceMap[node.id].status }} · {{ debugTraceMap[node.id].connectionType }}
             </div>
           </div>
 
@@ -1107,6 +1201,91 @@ onMounted(async () => {
         </div>
       </div>
     </div>
+
+    <el-dialog v-model="debugDialogVisible" title="规则链调试运行" width="980px" destroy-on-close>
+      <div class="debug-dialog-content">
+        <el-form class="debug-form" label-width="90px" size="small">
+          <el-form-item label="消息类型">
+            <el-radio-group v-model="debugForm.messageType">
+              <el-radio-button label="PROPERTY">
+                属性
+              </el-radio-button>
+              <el-radio-button label="EVENT">
+                事件
+              </el-radio-button>
+              <el-radio-button label="ONLINE">
+                上线
+              </el-radio-button>
+              <el-radio-button label="OFFLINE">
+                下线
+              </el-radio-button>
+            </el-radio-group>
+          </el-form-item>
+          <el-form-item label="设备Key">
+            <el-input v-model="debugForm.deviceKey" placeholder="deviceKey" />
+          </el-form-item>
+          <el-form-item label="设备名称">
+            <el-input v-model="debugForm.deviceName" placeholder="设备名称" />
+          </el-form-item>
+          <el-form-item label="属性JSON">
+            <el-input v-model="debugForm.propertiesJson" type="textarea" :rows="5" placeholder="{ &quot;temperature&quot;: 36.5 }" />
+          </el-form-item>
+          <el-form-item label="事件标识">
+            <el-input v-model="debugForm.eventIdentifier" placeholder="event identifier，例如 high_temperature" />
+          </el-form-item>
+          <el-form-item label="事件参数">
+            <el-input v-model="debugForm.eventParamsJson" type="textarea" :rows="3" placeholder="{ &quot;level&quot;: &quot;HIGH&quot; }" />
+          </el-form-item>
+          <el-form-item label="扩展变量">
+            <el-input v-model="debugForm.enrichedDataJson" type="textarea" :rows="3" placeholder="{ &quot;tenant&quot;: &quot;demo&quot; }" />
+          </el-form-item>
+        </el-form>
+
+        <div class="debug-result-panel">
+          <div class="debug-result-header">
+            <div>
+              <strong>执行轨迹</strong>
+              <span v-if="debugResult" class="debug-summary">
+                {{ debugResult.success ? '成功' : '失败' }} · {{ debugResult.executedNodeCount || 0 }} 个节点 · {{ debugResult.durationMs || 0 }}ms
+              </span>
+            </div>
+            <el-button type="primary" :loading="debugRunning" @click="handleDebugRun">
+              运行调试
+            </el-button>
+          </div>
+
+          <el-empty v-if="!debugResult" description="运行后展示节点执行轨迹" />
+          <el-timeline v-else class="debug-timeline">
+            <el-timeline-item
+              v-for="trace in debugResult.traces || []"
+              :key="`${trace.nodeId}-${trace.timestamp}`"
+              :type="getTraceStatusType(trace.status)"
+              :timestamp="trace.timestamp"
+            >
+              <div class="trace-card">
+                <div class="trace-title">
+                  <span>{{ trace.nodeName || trace.nodeId }}</span>
+                  <el-tag size="small" :type="getTraceStatusType(trace.status)">
+                    {{ trace.status }} / {{ trace.connectionType }} / {{ trace.durationMs || 0 }}ms
+                  </el-tag>
+                </div>
+                <div class="trace-detail">
+                  {{ trace.detail || trace.error || '无详情' }}
+                </div>
+                <el-collapse>
+                  <el-collapse-item title="输入快照" name="input">
+                    <pre>{{ formatJson(trace.input) }}</pre>
+                  </el-collapse-item>
+                  <el-collapse-item title="输出快照" name="output">
+                    <pre>{{ formatJson(trace.output) }}</pre>
+                  </el-collapse-item>
+                </el-collapse>
+              </div>
+            </el-timeline-item>
+          </el-timeline>
+        </div>
+      </div>
+    </el-dialog>
 
     <!-- 节点创建菜单 -->
     <Teleport to="body">
@@ -1159,18 +1338,20 @@ onMounted(async () => {
   align-items: center;
   padding: var(--space-md) var(--space-lg);
 
-  .header-left {
+  .header-left,
+  .header-right {
     display: flex;
     align-items: center;
     gap: var(--space-md);
+  }
 
+  .header-left {
     .title {
       font-size: 18px;
       font-weight: 600;
     }
   }
 }
-
 .editor-main {
   flex: 1;
   display: flex;
@@ -1376,6 +1557,14 @@ onMounted(async () => {
         0 6px 20px rgba(0, 0, 0, 0.15),
         0 0 0 3px rgba(99, 102, 241, 0.2);
     }
+    &.debug-success {
+      border-color: #10b981;
+      box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.18);
+    }
+    &.debug-failed {
+      border-color: #ef4444;
+      box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+    }
     // 输入节点样式（绿色边框）
     &.is-input {
       border-color: #10b981;
@@ -1491,6 +1680,18 @@ onMounted(async () => {
         font-size: 11px;
         color: var(--iot-color-text-muted);
       }
+      .node-debug-badge {
+        margin-top: 4px;
+        font-size: 10px;
+        font-weight: 600;
+        color: #047857;
+        background: rgba(16, 185, 129, 0.1);
+        border-radius: var(--radius-sm);
+        padding: 2px 6px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
   }
 }
@@ -1530,6 +1731,76 @@ onMounted(async () => {
     }
   }
 }
+
+.debug-dialog-content {
+  display: grid;
+  grid-template-columns: 380px 1fr;
+  gap: var(--space-lg);
+  min-height: 520px;
+
+  .debug-form {
+    padding-right: var(--space-md);
+    border-right: 1px solid var(--iot-color-border);
+  }
+
+  .debug-result-panel {
+    min-width: 0;
+  }
+
+  .debug-result-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--space-md);
+  }
+
+  .debug-summary {
+    margin-left: var(--space-sm);
+    color: var(--iot-color-text-muted);
+    font-size: 12px;
+  }
+
+  .debug-timeline {
+    max-height: 500px;
+    overflow-y: auto;
+    padding-right: var(--space-sm);
+  }
+
+  .trace-card {
+    padding: var(--space-sm) var(--space-md);
+    border: 1px solid var(--iot-color-border);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.7);
+  }
+
+  .trace-title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-sm);
+    margin-bottom: 6px;
+    font-weight: 600;
+  }
+
+  .trace-detail {
+    margin-bottom: var(--space-sm);
+    color: var(--iot-color-text-secondary);
+    font-size: 12px;
+  }
+
+  pre {
+    margin: 0;
+    padding: var(--space-sm);
+    max-height: 180px;
+    overflow: auto;
+    border-radius: var(--radius-sm);
+    background: #0f172a;
+    color: #d1fae5;
+    font-size: 12px;
+    line-height: 1.5;
+  }
+}
+
 // 暗色模式适配
 :global(.dark) {
   .canvas-panel {


### PR DESCRIPTION

## Changes

- **ScriptFilterNode**: GraalJS-based filter node for conditional rule branching
- **Rule-chain validation**: POST /rule-chain/validate endpoint with connectivity, entry, cycle, and field checks
- **Debug path highlight**: executedConnections in debug result + animated CSS flow in editor
- **Signed HTTP push**: HMAC-signed webhook push with test endpoint
- **JS protocol debug testing**: infrastructure for debugging JS protocol nodes

See individual commits for details: hashed out in 4 commits (7233277 → 52213ad → c96fd97 → 142919e)

## Verification
- iot-server: 45/45 tests passed
- iot-web: pnpm lint + pnpm build passed
- No sensitive content in diff
